### PR TITLE
Spark's merge_with_warning (deps/spark/lib/spark/dsl.ex:794) is uncon…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,6 +422,34 @@ geometry rebranding works uniformly.
   leaves create/update through their own domain APIs but reads surface them
   transparently via projection.
 
+### Fragment composition discipline — `jason do` / `outstanding do` live on leaves
+
+Spark's `merge_with_warning` (`deps/spark/lib/spark/dsl.ex:794`) is
+unconditional — there is no "this override is deliberate" opt-out. Whenever
+two fragments write different values to the same `jason.pick` /
+`outstanding.expect` opt, a compile-time warning fires regardless of intent.
+
+The cascade pattern requires every subtype fragment (`BaseGeographicAddress`
+etc.) and every consumer leaf to declare a wider `jason.pick` /
+`outstanding.expect` than any base default would provide. To avoid noise,
+**`BasePlace` / `BaseParty` / `BaseInstance` do not declare `jason do` or
+`outstanding do`**. Each concrete leaf carries its own:
+
+- Abstract readers (`Provider.Place`/`Provider.Party`/`Provider.Instance`)
+  ship the base shape — id, href, name, referred_type, type — for placeholder
+  records and projection bootstrap.
+- Cascade subtype fragments declare the union of base + subtype fields with
+  TMF camelCase renames.
+- Consumer leaves declare their own union per their domain shape.
+
+`BasePlace.encode_geo_json/2` stays as a static helper on `BasePlace` (not in
+a `jason do` block) — subtype fragments and consumer leaves reference it
+from their own `jason.customize`. Same idiom would apply to any future helper
+on `BaseParty` / `BaseInstance`.
+
+This is a deliberate departure from the "fragments carry defaults" idiom
+some Ash extensions use. It came out of #181.
+
 ### PlaceRef / PartyRef belongs_to stay at the abstract reader (Option C)
 
 The cascade does **not** migrate the typed `belongs_to` on PlaceRef/PartyRef to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 ## Unreleased
 
+### Bug Fixes
+
+* **Eliminate fragment-override warnings on cascade leaves** (#181) — Spark's `merge_with_warning` was firing during compile time whenever a subtype fragment (`BaseGeographicAddress`/`Site`/`Location`, `BaseOrganization`/`Individual`) declared a wider `jason.pick` / `outstanding.expect` than `BasePlace` / `BaseParty`. The merge logic has no opt-out for deliberate overrides. Fix: move `jason do` and `outstanding do` off `BasePlace` and `BaseParty` entirely; each concrete leaf carries its own declaration:
+
+  - Abstract readers (`Provider.Place`, `Provider.Party`) now declare their own base-shape `jason do` and `outstanding do` (previously inherited from the base fragment)
+  - Cascade subtype fragments continue to declare their own (no change)
+  - Test-support consumer leaves were already declaring their own (audit confirmed)
+  - `BasePlace.encode_geo_json/2` stays as a static helper that subtype fragments and consumer leaves reference from their own `jason.customize`
+
+  Documented as cascade discipline in `usage-rules.md` and `AGENTS.md`. Zero behaviour change; 757 tests + 90 doctests still pass.
+
 ### Features
 
 * **Party subtype cascade — `BaseParty` → typed subtype leaves** (#186) — TMF632 Organization and Individual now ship as concrete leaves built from fragment composition (`BaseParty` + `BaseOrganization` / `BaseIndividual`). Consumer leaves (e.g. `MyApp.Carrier`) compose the same two fragments alongside their own attributes.

--- a/lib/diffo/provider/components/base_party.ex
+++ b/lib/diffo/provider/components/base_party.ex
@@ -291,13 +291,13 @@ defmodule Diffo.Provider.BaseParty do
     prepare build(sort: [id: :asc, name: :asc])
   end
 
-  jason do
-    pick [:id, :href, :name, :referred_type, :type]
-    compact true
-    rename referred_type: "@referredType", type: "@type"
-  end
-
-  outstanding do
-    expect [:id, :name, :referred_type, :type]
-  end
+  # Note: `jason do` and `outstanding do` are NOT declared on this fragment.
+  # Spark fragment merge emits a compile-time warning whenever two fragments
+  # write to the same `jason.pick` / `outstanding.expect` opt — and every
+  # cascade subtype fragment (`BaseOrganization`/`Individual`) and every
+  # consumer leaf needs to declare a wider pick than this base would.
+  # Keeping these declarations off the base fragment eliminates the warnings
+  # cleanly. Each concrete leaf (abstract `Provider.Party`, subtype fragments,
+  # consumer leaves like `MyApp.Carrier`) declares its own `jason do` and
+  # `outstanding do`.
 end

--- a/lib/diffo/provider/components/base_place.ex
+++ b/lib/diffo/provider/components/base_place.ex
@@ -279,16 +279,17 @@ defmodule Diffo.Provider.BasePlace do
     prepare build(sort: [id: :asc, name: :asc])
   end
 
-  jason do
-    pick [:id, :href, :name, :referred_type, :type, :location, :bounds]
-    compact true
-    rename referred_type: "@referredType", type: "@type"
-    customize &Diffo.Provider.BasePlace.encode_geo_json/2
-  end
-
-  outstanding do
-    expect [:id, :name, :referred_type, :type]
-  end
+  # Note: `jason do` and `outstanding do` are NOT declared on this fragment.
+  # Spark fragment merge emits a compile-time warning whenever two fragments
+  # write to the same `jason.pick` / `outstanding.expect` opt — and every
+  # cascade subtype fragment (`BaseGeographicAddress`/`Site`/`Location`) and
+  # every consumer leaf needs to declare a wider pick than this base would.
+  # Keeping these declarations off the base fragment eliminates the warnings
+  # cleanly. Each concrete leaf (abstract `Provider.Place`, subtype fragments,
+  # consumer leaves like `MyApp.SydneyExchange`) declares its own `jason do`
+  # and `outstanding do`. `encode_geo_json/2` below remains as a static helper
+  # that subtype fragments and consumer leaves reference from their own
+  # `jason.customize`.
 
   @doc false
   def encode_geo_json(result, record) do

--- a/lib/diffo/provider/components/party.ex
+++ b/lib/diffo/provider/components/party.ex
@@ -53,4 +53,14 @@ defmodule Diffo.Provider.Party do
     description "An Ash Resource for a TMF Party"
     plural_name :parties
   end
+
+  jason do
+    pick [:id, :href, :name, :referred_type, :type]
+    compact true
+    rename referred_type: "@referredType", type: "@type"
+  end
+
+  outstanding do
+    expect [:id, :name, :referred_type, :type]
+  end
 end

--- a/lib/diffo/provider/components/place.ex
+++ b/lib/diffo/provider/components/place.ex
@@ -49,4 +49,15 @@ defmodule Diffo.Provider.Place do
     description "An Ash Resource for a TMF Place"
     plural_name :places
   end
+
+  jason do
+    pick [:id, :href, :name, :referred_type, :type, :location, :bounds]
+    compact true
+    rename referred_type: "@referredType", type: "@type"
+    customize &Diffo.Provider.BasePlace.encode_geo_json/2
+  end
+
+  outstanding do
+    expect [:id, :name, :referred_type, :type]
+  end
 end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -101,6 +101,30 @@ Action naming convention on cascade leaves: `:build` for create, `:define` for
 update, both accepting the union of base + subtype fields. `:build` sets the
 TMF `:type` discriminator automatically.
 
+### `jason do` and `outstanding do` live on leaves, not on `Base*` fragments
+
+Spark's fragment merge emits a compile-time warning whenever two fragments
+write to the same `jason.pick` / `outstanding.expect` opt — and every cascade
+subtype fragment and every consumer leaf needs a wider pick than any base
+default would provide. To eliminate the warnings cleanly, **`BasePlace` /
+`BaseParty` / `BaseInstance` do not declare `jason do` or `outstanding do`**.
+
+Each concrete leaf declares its own:
+
+- **Abstract readers** (`Provider.Place` / `Provider.Party` / `Provider.Instance`)
+  carry the base shape (id, href, name, referred_type, type) for placeholder
+  records.
+- **Cascade subtype fragments** (`BaseGeographicAddress`/`Site`/`Location`,
+  `BaseOrganization`/`Individual`) carry the union of base + subtype fields
+  with TMF camelCase renames.
+- **Consumer leaves** (`MyApp.Carrier`, `MyApp.SydneyExchange`, etc.) declare
+  their own `jason do` and `outstanding do` covering base + their domain-
+  specific fields. See the docstring examples on each Base* fragment.
+
+This is a deliberate departure from the "fragments carry defaults" idiom that
+some Ash extensions use. Spark's `merge_with_warning` has no opt-out for
+deliberate overrides, so the only way to avoid noise is to not declare twice.
+
 ### Provider.Place is plumbing — use the dispatcher API
 
 `Diffo.Provider.Place` is **kept in core minimally** as the abstract reader


### PR DESCRIPTION
…ditional

— there's no opt-out for deliberate fragment overrides. Every cascade subtype fragment (BaseGeographicAddress/Site/Location, BaseOrganization/Individual) necessarily declares a wider jason.pick / outstanding.expect than the base fragment can provide, so the warnings fire on every compile.

Fix: move jason do and outstanding do off BasePlace and BaseParty entirely; each concrete leaf carries its own.

* BasePlace + BaseParty — jason do and outstanding do removed; moduledoc comment notes where they live now and why. BasePlace.encode_geo_json/2 stays as a static helper that subtype fragments reference from their own jason.customize.

* Provider.Place + Provider.Party (abstract readers) — gained their own base-shape jason do + outstanding do (preserving exactly what BasePlace / BaseParty used to emit). No wire-shape change.

* Cascade subtype fragments + test-support consumer leaves — already declared their own; audit confirmed no orphans (5/5 test-support leaves carry both declarations).

* AGENTS.md — new "Fragment composition discipline — jason do / outstanding do live on leaves" subsection in the Fat* / cascade area, documenting the Spark merge-with-warning rationale and the leaf-declaration rule.

* usage-rules.md — new subsection under the Place cascade section.

* CHANGELOG.md — bug-fix entry under Unreleased noting the warning elimination is zero behaviour change.

* 757 tests + 90 doctests passing; zero compile warnings on the cascade leaves.