### PR TITLE
Surface inherited values in the TMF JSON view (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 ## Unreleased
 
+### Features
+
+* **Inherited and reverse-inherited values now surface in the TMF JSON view** (#173) — a new sibling transformer `Diffo.Provider.Extension.Transformers.TransformInheritedJason` runs after `TransformInheritedRefs` (calc injection) and before `AshJason.Resource.Transformer` (encoder generation). For each inherited kind a resource declares, it injects a focused `jason.customize` step so loaded inherited calcs reach the consumer-visible array — no per-consumer customize required:
+
+  - `inherited_place` → the `place` array, as a simulated `PlaceRef` (carries the declared role plus the inherited place's flattened identity; there is no backing ref node — the inheritance simulates it)
+  - `inherited_party` → the `relatedParty` array, as a simulated `PartyRef`
+  - `inherited_characteristic` / `reverse_inherited_characteristic` → the `serviceCharacteristic` / `resourceCharacteristic` array, as ordinary typed characteristics
+
+  Surfaced entries appear after the instance's local entries. `%Diffo.Unknown{}` sentinels are filtered out before any ref wrapping — X-state is the Diffo diagnostic surface, not the TMF wire. Unloaded calcs (`%Ash.NotLoaded{}`) contribute nothing; load the calc to include it. Wire-shape concerns stay in this transformer; calc-shape concerns stay in `TransformInheritedRefs`.
+
 ### Bug Fixes
 
 * **`Instance.Party.validate_constraints` skips inherited declarations** (#183) — the validator's `Enum.reject(&(&1.reference || &1.calculate))` was iterating ALL party declarations and KeyError'd on `InheritedPartyDeclaration` (which has no `:reference`/`:calculate` fields). Same shape of bug as the persister fix in #172 for inherited characteristics. Fix: filter to `Diffo.Provider.Extension.PartyDeclaration` before the reject — inherited variants are pre-validated by their declaration entity and have no min/max constraints to enforce.

--- a/lib/diffo/provider/components/instance/util.ex
+++ b/lib/diffo/provider/components/instance/util.ex
@@ -4,6 +4,129 @@
 
 defmodule Diffo.Provider.Instance.Util do
   @moduledoc false
+  alias Diffo.Provider.Extension.Info
+  alias Diffo.Provider.Extension.InheritedPlaceDeclaration
+  alias Diffo.Provider.Extension.InheritedPartyDeclaration
+  alias Diffo.Provider.Extension.InheritedCharacteristicDeclaration
+  alias Diffo.Provider.Extension.ReverseInheritedCharacteristicDeclaration
+
+  # Each of the three functions below is injected as its own `jason.customize`
+  # step by `Diffo.Provider.Extension.Transformers.TransformInheritedJason`, but
+  # only for the inherited kinds a resource actually declares — one focused step
+  # per TMF array. They run after `BaseInstance`'s own customize, so the array
+  # keys are already in TMF form (`:place`, `:relatedParty`,
+  # `:serviceCharacteristic` / `:resourceCharacteristic`).
+  #
+  # Each reads the matching calc(s) off the record. A `%Ash.NotLoaded{}` (the
+  # consumer didn't load it) or `nil` contributes nothing; `%Diffo.Unknown{}`
+  # sentinels are dropped — X-state is the Diffo diagnostic surface, not the TMF
+  # wire.
+  #
+  # Places and parties surface as `PlaceRef` / `PartyRef`-shaped entries: the
+  # inheritance has no backing ref node, but the ref carries "what this place /
+  # party means to me" (the declared role), which is an essential part of the
+  # TMF shape. We simulate it by wrapping the inherited target in an ephemeral
+  # (non-persisted) `PlaceRef` / `PartyRef` stamped with the declaration role and
+  # letting the ref's own `Jason.Encoder` produce the exact wire shape. Typed
+  # characteristics carry their own `name`, so they surface as-is.
+  #
+  # Ordering follows the convention: locals stay first (already in `result`),
+  # then inherited values; within characteristics, inherited before
+  # reverse-inherited.
+
+  @doc "Surfaces `inherited_place` calc results into the `place` array as simulated `PlaceRef`s."
+  def surface_inherited_places(result, record) do
+    refs =
+      record.__struct__
+      |> inherited_place_roles()
+      |> Enum.flat_map(fn role ->
+        record
+        |> loaded_values(role)
+        |> Enum.map(&%Diffo.Provider.PlaceRef{role: role, place: &1})
+      end)
+
+    append_values(result, :place, refs)
+  end
+
+  @doc "Surfaces `inherited_party` calc results into the `relatedParty` array as simulated `PartyRef`s."
+  def surface_inherited_parties(result, record) do
+    refs =
+      record.__struct__
+      |> inherited_party_roles()
+      |> Enum.flat_map(fn role ->
+        record
+        |> loaded_values(role)
+        |> Enum.map(&%Diffo.Provider.PartyRef{role: role, party: &1})
+      end)
+
+    append_values(result, :relatedParty, refs)
+  end
+
+  @doc """
+  Surfaces `inherited_characteristic` then `reverse_inherited_characteristic`
+  calc results into the `serviceCharacteristic` / `resourceCharacteristic` array.
+  """
+  def surface_inherited_characteristics(result, record) do
+    characteristics =
+      record.__struct__
+      |> inherited_characteristic_names()
+      |> Enum.flat_map(&loaded_values(record, &1))
+
+    append_values(result, derive_characteristic_list_name(record.type), characteristics)
+  end
+
+  defp inherited_place_roles(resource) do
+    resource
+    |> Info.provider_places()
+    |> Enum.filter(&is_struct(&1, InheritedPlaceDeclaration))
+    |> Enum.map(& &1.role)
+  end
+
+  defp inherited_party_roles(resource) do
+    resource
+    |> Info.provider_parties()
+    |> Enum.filter(&is_struct(&1, InheritedPartyDeclaration))
+    |> Enum.map(& &1.role)
+  end
+
+  defp inherited_characteristic_names(resource) do
+    characteristics = Info.provider_characteristics(resource)
+
+    inherited =
+      characteristics
+      |> Enum.filter(&is_struct(&1, InheritedCharacteristicDeclaration))
+      |> Enum.map(& &1.role)
+
+    reverse =
+      characteristics
+      |> Enum.filter(&is_struct(&1, ReverseInheritedCharacteristicDeclaration))
+      |> Enum.map(& &1.name)
+
+    inherited ++ reverse
+  end
+
+  # Appends the surfaced values to the named array, preserving any locals already
+  # present.
+  defp append_values(result, nil, _values), do: result
+  defp append_values(result, _key, []), do: result
+
+  defp append_values(result, key, values) do
+    Diffo.Util.set(result, key, (Diffo.Util.get(result, key) || []) ++ values)
+  end
+
+  # The concrete values for an inherited calc: a `%Ash.NotLoaded{}` (consumer
+  # didn't load it) or `nil` yields none, and `%Diffo.Unknown{}` sentinels are
+  # dropped — X-state is the Diffo diagnostic surface, not the TMF wire. Rejecting
+  # Unknowns here (before any ref wrapping) keeps them off the wire entirely.
+  defp loaded_values(record, name) do
+    case Map.get(record, name) do
+      %Ash.NotLoaded{} -> []
+      nil -> []
+      list when is_list(list) -> Enum.reject(list, &is_struct(&1, Diffo.Unknown))
+      value -> if is_struct(value, Diffo.Unknown), do: [], else: [value]
+    end
+  end
+
   @doc false
   def category(result, record) do
     specification = Map.get(record, :specification)

--- a/lib/diffo/provider/extension.ex
+++ b/lib/diffo/provider/extension.ex
@@ -713,7 +713,8 @@ defmodule Diffo.Provider.Extension do
     transformers: [
       Diffo.Provider.Extension.Transformers.TransformRelationships,
       Diffo.Provider.Extension.Transformers.TransformBehaviour,
-      Diffo.Provider.Extension.Transformers.TransformInheritedRefs
+      Diffo.Provider.Extension.Transformers.TransformInheritedRefs,
+      Diffo.Provider.Extension.Transformers.TransformInheritedJason
     ],
     persisters: [
       Diffo.Provider.Extension.Persisters.PersistSpecification,

--- a/lib/diffo/provider/extension/transformers/transform_inherited_jason.ex
+++ b/lib/diffo/provider/extension/transformers/transform_inherited_jason.ex
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 diffo contributors <https://github.com/diffo-dev/diffo/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Diffo.Provider.Extension.Transformers.TransformInheritedJason do
+  @moduledoc """
+  Surfaces inherited and reverse-inherited results into the TMF JSON view.
+
+  `TransformInheritedRefs` injects the Ash calculations for `inherited_place`,
+  `inherited_party`, `inherited_characteristic`, and
+  `reverse_inherited_characteristic` so they are loadable via `Ash.load/2`. That
+  alone keeps the brought-up values off the consumer-visible TMF surface — the
+  calc result never reaches the `place` / `relatedParty` / `serviceCharacteristic`
+  / `resourceCharacteristic` arrays on encode.
+
+  This transformer closes that gap. It appends one focused `jason.customize` step
+  per TMF array — but only for the inherited kinds the resource actually declares:
+
+    * `inherited_place` → `Diffo.Provider.Instance.Util.surface_inherited_places/2`
+      (the `place` array)
+    * `inherited_party` → `Diffo.Provider.Instance.Util.surface_inherited_parties/2`
+      (the `relatedParty` array)
+    * `inherited_characteristic` / `reverse_inherited_characteristic` →
+      `Diffo.Provider.Instance.Util.surface_inherited_characteristics/2`
+      (the `serviceCharacteristic` / `resourceCharacteristic` array)
+
+  Each step — at encode time — reads its inherited calc(s) off the record, drops
+  `%Diffo.Unknown{}` sentinels (X-state is the Diffo diagnostic surface, not the
+  TMF wire), and appends the concrete structs to its array. Each surfaced struct
+  encodes via its own `Jason.Encoder`, so subtype fidelity is preserved without
+  hand-building any TMF object here. See the `Diffo.Provider.Instance.Util`
+  functions for the runtime logic and the ordering convention.
+
+  Single responsibility by design: calc injection stays in `TransformInheritedRefs`
+  (an API concern), wire surfacing lives here (a TMF concern). The two evolve
+  independently.
+
+  Runs **after** `TransformInheritedRefs` (the calcs must exist) and **before**
+  `AshJason.Resource.Transformer` (which compiles the `jason do` steps into the
+  `Jason.Encoder` implementation).
+  """
+  use Spark.Dsl.Transformer
+  alias Spark.Dsl.Transformer
+  alias Diffo.Provider.Extension.InheritedPlaceDeclaration
+  alias Diffo.Provider.Extension.InheritedPartyDeclaration
+  alias Diffo.Provider.Extension.InheritedCharacteristicDeclaration
+  alias Diffo.Provider.Extension.ReverseInheritedCharacteristicDeclaration
+  alias Diffo.Provider.Instance.Util
+
+  @impl true
+  def after?(Diffo.Provider.Extension.Transformers.TransformInheritedRefs), do: true
+  def after?(_), do: false
+
+  @impl true
+  def before?(AshJason.Resource.Transformer), do: true
+  def before?(_), do: false
+
+  @impl true
+  def transform(dsl_state) do
+    places = Transformer.get_entities(dsl_state, [:provider, :places])
+    parties = Transformer.get_entities(dsl_state, [:provider, :parties])
+    characteristics = Transformer.get_entities(dsl_state, [:provider, :characteristics])
+
+    dsl_state =
+      dsl_state
+      |> maybe_add_step(
+        declared?(places, [InheritedPlaceDeclaration]),
+        &Util.surface_inherited_places/2
+      )
+      |> maybe_add_step(
+        declared?(parties, [InheritedPartyDeclaration]),
+        &Util.surface_inherited_parties/2
+      )
+      |> maybe_add_step(
+        declared?(characteristics, [
+          InheritedCharacteristicDeclaration,
+          ReverseInheritedCharacteristicDeclaration
+        ]),
+        &Util.surface_inherited_characteristics/2
+      )
+
+    {:ok, dsl_state}
+  end
+
+  defp maybe_add_step(dsl_state, false, _fun), do: dsl_state
+
+  defp maybe_add_step(dsl_state, true, fun) do
+    step = %AshJason.TransformerHelpers.Step{type: :customize, input: fun}
+    Transformer.add_entity(dsl_state, [:jason], step)
+  end
+
+  defp declared?(entities, declaration_modules) do
+    Enum.any?(entities, fn entity ->
+      Enum.any?(declaration_modules, &is_struct(entity, &1))
+    end)
+  end
+end

--- a/test/provider/extension/inherited_refs_test.exs
+++ b/test/provider/extension/inherited_refs_test.exs
@@ -20,7 +20,8 @@ defmodule Diffo.Provider.Extension.InheritedRefsTest do
       place =
         Diffo.Provider.create_place!(:GeographicSite, %{
           id: "LOC-TEST-INHERITED-001",
-          name: "Test Exchange"})
+          name: "Test Exchange"
+        })
 
       {:ok, card} = Servo.build_card(%{})
 
@@ -67,12 +68,14 @@ defmodule Diffo.Provider.Extension.InheritedRefsTest do
       place_a =
         Diffo.Provider.create_place!(:GeographicSite, %{
           id: "LOC-TEST-INHERITED-002",
-          name: "Exchange A"})
+          name: "Exchange A"
+        })
 
       place_b =
         Diffo.Provider.create_place!(:GeographicSite, %{
           id: "LOC-TEST-INHERITED-003",
-          name: "Exchange B"})
+          name: "Exchange B"
+        })
 
       {:ok, card_a} = Servo.build_card(%{})
       {:ok, card_b} = Servo.build_card(%{})
@@ -327,5 +330,182 @@ defmodule Diffo.Provider.Extension.InheritedRefsTest do
 
       assert shelf.assigned_cards == []
     end
+  end
+
+  describe "JSON surfacing (#173) — inherited values appear in TMF arrays" do
+    test "inherited_place surfaces into the place array on encode" do
+      place =
+        Diffo.Provider.create_place!(:GeographicSite, %{
+          id: "LOC-TEST-JSON-001",
+          name: "Test Exchange"
+        })
+
+      {:ok, card} = Servo.build_card(%{})
+
+      updates = [
+        card: [family: :ISAM, model: "EBLT48", technology: :adsl2Plus],
+        ports: [first: 1, last: 48, assignable_type: "ADSL2+"]
+      ]
+
+      {:ok, card} = Servo.define_card(card, %{characteristic_value_updates: updates})
+      {:ok, card} = Servo.lifecycle_card(card, %{resource_state: :operating})
+
+      Diffo.Provider.create_place_ref!(%{
+        instance_id: card.id,
+        role: :location,
+        place_id: place.id
+      })
+
+      {:ok, service} = Servo.build_access_service(%{})
+
+      {:ok, _card} =
+        Servo.assign_port(card, %{
+          assignment: %Assignment{
+            assignee_id: service.id,
+            operation: :auto_assign,
+            alias: :primary
+          }
+        })
+
+      encoded =
+        service.id
+        |> reload_with([:primary])
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      # Surfaced as a simulated PlaceRef: carries the declaration role ("primary")
+      # and the inherited place's flattened identity, with no backing ref node.
+      assert [
+               %{
+                 "id" => "LOC-TEST-JSON-001",
+                 "role" => "primary",
+                 "@type" => "GeographicSite"
+               }
+             ] = encoded["place"]
+    end
+
+    test "inherited_party surfaces into the relatedParty array as a simulated PartyRef" do
+      party =
+        Diffo.Provider.create_party!(:Organization, %{id: "ORG-TEST-JSON-1", name: "Test Org"})
+
+      {:ok, card} = Servo.build_card(%{})
+
+      updates = [
+        card: [family: :ISAM, model: "EBLT48", technology: :adsl2Plus],
+        ports: [first: 1, last: 48, assignable_type: "ADSL2+"]
+      ]
+
+      {:ok, card} = Servo.define_card(card, %{characteristic_value_updates: updates})
+      {:ok, card} = Servo.lifecycle_card(card, %{resource_state: :operating})
+
+      Diffo.Provider.create_party_ref!(%{
+        instance_id: card.id,
+        role: :provider,
+        party_id: party.id
+      })
+
+      {:ok, service} = Servo.build_access_service(%{})
+
+      {:ok, _card} =
+        Servo.assign_port(card, %{
+          assignment: %Assignment{
+            assignee_id: service.id,
+            operation: :auto_assign,
+            alias: :primary
+          }
+        })
+
+      encoded =
+        service.id
+        |> reload_with([:owner])
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      assert [
+               %{"id" => "ORG-TEST-JSON-1", "role" => "owner", "@type" => "Organization"}
+             ] = encoded["relatedParty"]
+    end
+
+    test "inherited_characteristic surfaces into the serviceCharacteristic array on encode" do
+      {:ok, card} = Servo.build_card(%{})
+
+      updates = [
+        card: [family: :ISAM, model: "EBLT48", technology: :adsl2Plus],
+        ports: [first: 1, last: 48, assignable_type: "ADSL2+"]
+      ]
+
+      {:ok, card} = Servo.define_card(card, %{characteristic_value_updates: updates})
+      {:ok, card} = Servo.lifecycle_card(card, %{resource_state: :operating})
+
+      {:ok, service} = Servo.build_access_service(%{})
+
+      {:ok, _card} =
+        Servo.assign_port(card, %{
+          assignment: %Assignment{
+            assignee_id: service.id,
+            operation: :auto_assign,
+            alias: :primary
+          }
+        })
+
+      encoded =
+        service.id
+        |> reload_with([:card])
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      assert Enum.any?(encoded["serviceCharacteristic"] || [], &Map.has_key?(&1, "name"))
+    end
+
+    test "Diffo.Unknown sentinels are filtered off the wire" do
+      # Card assigned via :primary but with no PlaceRef at :location — the
+      # inherited_place calc yields a %Diffo.Unknown{}, which must not surface.
+      {:ok, card} = Servo.build_card(%{})
+
+      updates = [
+        card: [family: :ISAM, model: "EBLT48", technology: :adsl2Plus],
+        ports: [first: 1, last: 48, assignable_type: "ADSL2+"]
+      ]
+
+      {:ok, card} = Servo.define_card(card, %{characteristic_value_updates: updates})
+      {:ok, card} = Servo.lifecycle_card(card, %{resource_state: :operating})
+
+      {:ok, service} = Servo.build_access_service(%{})
+
+      {:ok, _card} =
+        Servo.assign_port(card, %{
+          assignment: %Assignment{
+            assignee_id: service.id,
+            operation: :auto_assign,
+            alias: :primary
+          }
+        })
+
+      encoded =
+        service.id
+        |> reload_with([:primary])
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      refute Map.has_key?(encoded, "place")
+    end
+
+    test "not loading the inherited calc leaves the array untouched" do
+      {:ok, service} = Servo.build_access_service(%{})
+
+      encoded =
+        service.id
+        |> reload_with([])
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      refute Map.has_key?(encoded, "place")
+    end
+  end
+
+  defp reload_with(id, loads) do
+    Diffo.Test.Instance.AccessService
+    |> Ash.get!(id, domain: Servo)
+    |> Ash.load!(loads, domain: Servo)
   end
 end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -753,6 +753,34 @@ Options:
 The DSL entity must be declared in the correct section (`places do` for `inherited_place`,
 `parties do` for `inherited_party`). The generated calculation name matches the declared role.
 
+### JSON surfacing
+
+When the calculation is loaded and the instance is JSON-encoded, the inherited values
+surface automatically in the corresponding TMF array — no per-consumer `jason` customize
+required:
+
+- `inherited_place` → the `place` array, as a simulated `PlaceRef` (carries the declared
+  role plus the inherited place's flattened identity; there is no backing ref node, the
+  inheritance simulates it)
+- `inherited_party` → the `relatedParty` array, as a simulated `PartyRef`
+- `inherited_characteristic` / `reverse_inherited_characteristic` → the
+  `serviceCharacteristic` / `resourceCharacteristic` array, as ordinary typed
+  characteristics
+
+Surfaced entries appear after the instance's local entries. `%Diffo.Unknown{}` sentinels
+(the "tried and couldn't determine" X-state) are filtered out — they are a Diffo-level
+diagnostic surface, not the TMF wire. Values you have not loaded simply do not surface;
+load the calculation (e.g. `Ash.load(instance, [:exchange])`) to include it.
+
+```jsonc
+// AccessService with inherited_place :primary, inherited_party :owner, inherited_characteristic :card
+{
+  "place":         [{ "role": "primary", "id": "LOC-1", "name": "Exchange", "@type": "GeographicSite" }],
+  "relatedParty":  [{ "role": "owner",   "id": "ORG-1", "name": "Owner Co", "@type": "Organization" }],
+  "serviceCharacteristic": [{ "name": "card", "value": { "model": "EBLT48" } }]
+}
+```
+
 ## Field calculation modules
 
 Three general-purpose calculation modules cover reading fields across the assignment and


### PR DESCRIPTION
New sibling transformer TransformInheritedJason runs after TransformInheritedRefs (calc injection) and before AshJason's encoder generation, injecting one focused jason.customize step per TMF array — only for the inherited kinds a resource declares:

- inherited_place      → place[]        (simulated PlaceRef, carries role)
- inherited_party      → relatedParty[] (simulated PartyRef, carries role)
- inherited_characteristic / reverse_inherited_characteristic
                       → service/resourceCharacteristic[]

Places/parties wrap the inherited target in an ephemeral (non-persisted) PlaceRef/PartyRef so the declared role surfaces with no backing node; the ref's own encoder produces the exact wire shape. %Diffo.Unknown{} sentinels are filtered before wrapping; unloaded calcs contribute nothing. Wire-shape concern lives here, calc-shape stays in TransformInheritedRefs.