### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 <!-- changelog -->
 
+## [v0.6.0](https://github.com/diffo-dev/diffo/compare/v0.5.1...v0.6.0) (2026-06-02)
+### Breaking Changes:
+
+* unify inherited_characteristic into a general traversal DSL (#213) by Matt Beanland
+
+
+
+### Features:
+
+* add traversal foundation for unified inherited_characteristic (#213) by Matt Beanland
+
+### Bug Fixes:
+
+* ship CHANGELOG in the hex package and silence the git_ops warning by Matt Beanland
+
 ## [v0.5.1](https://github.com/diffo-dev/diffo/compare/v0.5.0...v0.5.1) (2026-06-01)
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Diffo.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.5.1"
+  @version "0.6.0"
   @name "Diffo"
   @description "TMF Service and Resource Manager with a difference"
   @github_url "https://github.com/diffo-dev/diffo"


### PR DESCRIPTION
Release **v0.6.0** (run via `mix git_ops.release --no-major`).

### Breaking Changes
- Unify `inherited_characteristic` into a general traversal DSL (#213) — supersedes #211 and #212. `reverse_inherited_characteristic` retired; `via:` is now a per-hop chain over assignment **and** relationship edges in either direction, plus `read:` / `as:` / `collapse:`.

### Bug Fixes
- Ship `CHANGELOG` in the hex package and silence the git_ops warning.

### Docs (not in changelog)
- New `use_diffo_place_geo` livebook (GeographicLocation + GeoJSON, with graph-native `st_distance` spatial calculations), `inherited_characteristic` how-to coverage, and livebook/README dep bumps to `~> 0.6.0`.

See `CHANGELOG.md` for the generated entry.