### PR TITLE
docs: TMF673-675 Place numbering; place livebook projection + RF link…

### DIFF
--- a/documentation/how_to/use_diffo_place_geo.livemd
+++ b/documentation/how_to/use_diffo_place_geo.livemd
@@ -205,7 +205,7 @@ leaf resource it belongs to:
 AshNeo4j.worlds(sydney_cbd)
 ```
 
-## A spatial calculation — signal strength from distance
+## A spatial calculation — RF link budget from distance
 
 The out-of-the-box `Diffo.Provider.GeographicLocation` is just a leaf composing two
 fragments. Your domain can define its own — adding domain attributes and calculations — by
@@ -219,10 +219,60 @@ Elixir** against the loaded `%Geo.*{}` structs — and both paths agree, because
 matches Neo4j's WGS-84 distance model. No SQL, no PostGIS — the distance is computed in the
 graph.
 
-Here a `CellSite` adds a `transmit_power` (EIRP, in watts) and two **expression
-calculations**: the geodesic distance to a given point, and the received signal strength
-(power flux density, W/m²) — `transmit_power / (4·π·d²)` — derived from that distance. The
-target point comes in as a typed `:at` argument.
+Here a `CellSite` models a simple **free-space (Friis) RF link budget**, the way an engineer
+reads it — in **dBm**. It carries an `eirp_dbm` (Equivalent Isotropic Radiated Power, which
+folds in the transmit-antenna gain) and a `frequency_mhz`, and exposes three calculations of
+the signal at a given point:
+
+- `distance_m` — geodesic distance (the graph-native `st_distance_in_meters` expression).
+- `path_loss_db` — free-space path loss, `20·log10(d) + 20·log10(f) − 27.55` (d in m, f in MHz).
+- `rssi_dbm` — received signal level for an isotropic receiver: `eirp_dbm − path_loss_db`.
+
+> This is line-of-sight free space — the optimistic **floor**. A real CBD link loses tens of
+> dB more to buildings, clutter and foliage. Using EIRP (Tx) and an isotropic Rx keeps the
+> figure antenna-decoupled.
+
+The dB maths needs `log10`, which `Ash.Expr` doesn't provide, so the link budget is an Elixir
+calculation — while `distance_m` stays a pure graph expression. It reuses
+`AshNeo4j.Geo.haversine_meters/2` so its distance matches the `point.distance` the expression
+path uses:
+
+```elixir
+defmodule MyApp.LinkBudget do
+  @moduledoc "Free-space (Friis) link budget: path loss (dB) and isotropic RSSI (dBm)."
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, opts, _context) do
+    case opts[:metric] do
+      :rssi_dbm -> [:location, :eirp_dbm, :frequency_mhz]
+      :path_loss_db -> [:location, :frequency_mhz]
+    end
+  end
+
+  @impl true
+  def calculate(records, opts, context) do
+    %Geo.Point{coordinates: at} = context.arguments.at
+    Enum.map(records, &metric(opts[:metric], &1, at))
+  end
+
+  defp metric(:path_loss_db, %{location: %Geo.Point{coordinates: site}, frequency_mhz: f}, at),
+    do: fspl_db(AshNeo4j.Geo.haversine_meters(site, at), f)
+
+  defp metric(
+         :rssi_dbm,
+         %{location: %Geo.Point{coordinates: site}, eirp_dbm: eirp, frequency_mhz: f},
+         at
+       ),
+       do: Float.round(eirp - fspl_db(AshNeo4j.Geo.haversine_meters(site, at), f), 1)
+
+  # Friis free-space path loss; d in metres, f in MHz.
+  defp fspl_db(+0.0, _f), do: 0.0
+
+  defp fspl_db(d_m, f_mhz),
+    do: Float.round(20 * :math.log10(d_m) + 20 * :math.log10(f_mhz) - 27.55, 1)
+end
+```
 
 Your own leaf belongs in your own domain (the built-in
 `Diffo.Provider.GeographicLocation` already fills that role in the `Diffo.Provider`
@@ -230,9 +280,18 @@ domain):
 
 ```elixir
 defmodule MyApp.Geo do
-  use Ash.Domain, otp_app: :diffo, validate_config_inclusion?: false
+  use Ash.Domain,
+    otp_app: :diffo,
+    validate_config_inclusion?: false,
+    # writes the :Provider label on every node in this domain, so provider-side readers
+    # (e.g. Diffo.Provider.get_place_by_id!/1, which MATCHes [:Provider, :Place]) can find
+    # and project your leaf — see Diffo.Provider.DomainFragment
+    fragments: [Diffo.Provider.DomainFragment]
 
   resources do
+    # the domain is defined before the leaf below, so it can't list it explicitly —
+    # allow_unregistered? lets `domain: MyApp.Geo` accept MyApp.CellSite at runtime
+    allow_unregistered? true
   end
 end
 ```
@@ -245,8 +304,9 @@ defmodule MyApp.CellSite do
 
   attributes do
     attribute :cell_id, :string, public?: true
-    # equivalent isotropically radiated power, in watts
-    attribute :transmit_power, :float, public?: true
+    # Equivalent Isotropic Radiated Power, in dBm (folds in the Tx antenna gain)
+    attribute :eirp_dbm, :float, public?: true
+    attribute :frequency_mhz, :float, public?: true, default: 3500.0
   end
 
   calculations do
@@ -258,15 +318,15 @@ defmodule MyApp.CellSite do
       end
     end
 
-    # signal strength (power flux density, W/m²) from EIRP and that distance
-    calculate :signal_strength,
-              :float,
-              expr(
-                transmit_power /
-                  (4 * 3.141592653589793 *
-                     st_distance_in_meters(location, ^arg(:at)) *
-                     st_distance_in_meters(location, ^arg(:at)))
-              ) do
+    # free-space path loss (dB) and isotropic received signal level (dBm)
+    calculate :path_loss_db, :float, {MyApp.LinkBudget, metric: :path_loss_db} do
+      argument :at, AshGeo.GeoJson do
+        constraints geo_types: [:point], force_srid: 4326
+        allow_nil? false
+      end
+    end
+
+    calculate :rssi_dbm, :float, {MyApp.LinkBudget, metric: :rssi_dbm} do
       argument :at, AshGeo.GeoJson do
         constraints geo_types: [:point], force_srid: 4326
         allow_nil? false
@@ -276,14 +336,25 @@ defmodule MyApp.CellSite do
 
   actions do
     create :build do
-      accept [:id, :href, :name, :location, :bounds, :accuracy, :cell_id, :transmit_power]
+      accept [
+        :id,
+        :href,
+        :name,
+        :location,
+        :bounds,
+        :accuracy,
+        :cell_id,
+        :eirp_dbm,
+        :frequency_mhz
+      ]
+
       change set_attribute(:type, :GeographicLocation)
     end
   end
 end
 ```
 
-Build a tower, then ask for the distance and signal strength at a nearby point — the `:at`
+Build a tower, then ask for the distance, path loss and RSSI at a nearby point — the `:at`
 point is supplied as each calculation's argument when you load it:
 
 ```elixir
@@ -294,20 +365,24 @@ tower =
       id: "CELL-SYD-1",
       name: "Sydney CBD Tower",
       location: %Geo.Point{coordinates: {151.2093, -33.8688}, srid: 4326},
-      transmit_power: 40.0,
+      eirp_dbm: 60.0,
+      frequency_mhz: 3500.0,
       cell_id: "ENB-1001"
     },
     action: :build,
     domain: MyApp.Geo
   )
 
-# Town Hall, ~500 m south-west
+# Town Hall, ~513 m south-west
 town_hall = %Geo.Point{coordinates: {151.2073, -33.8731}, srid: 4326}
 
 tower
-|> Ash.load!([distance_m: %{at: town_hall}, signal_strength: %{at: town_hall}], domain: MyApp.Geo)
-|> then(&{&1.distance_m, &1.signal_strength})
-# => {~513.0, ~1.2e-5}   (metres, W/m²)
+|> Ash.load!(
+  [distance_m: %{at: town_hall}, path_loss_db: %{at: town_hall}, rssi_dbm: %{at: town_hall}],
+  domain: MyApp.Geo
+)
+|> then(&{&1.distance_m, &1.path_loss_db, &1.rssi_dbm})
+# => {~513.0, ~97.5, ~-37.5}   (metres, dB, dBm) — free-space at 3.5 GHz
 ```
 
 The same `st_*` functions shine in a **query filter**, where they push down to Neo4j —
@@ -323,7 +398,43 @@ MyApp.CellSite
 
 `BaseGeographicLocation` carries the `accuracy` attribute, the geometry validation, and the
 TMF675 `geoJson` encoding; the leaf adds only what is specific to it — here `cell_id`,
-`transmit_power`, and the two spatial calculations.
+`eirp_dbm` / `frequency_mhz`, and the three calculations.
+
+### Projecting a custom leaf
+
+A custom leaf projects exactly like the built-in subtypes — **provided its domain opts into
+provider polymorphism**. Because `MyApp.Geo` composes `Diffo.Provider.DomainFragment`, every
+node in it also gets the `Provider` label. So the node carries one label per world it belongs
+to: `Geo` (the domain), `CellSite` (the module), `Place` (from `BasePlace`), and `Provider`
+(the domain fragment):
+
+```elixir
+tower.__metadata__.labels
+# => ["Geo", "CellSite", "Place", "Provider"]
+```
+
+Note there's no `GeographicLocation` label — the subtype fragments don't add one; subtype
+identity is the module label plus the `:type` property. The **`Provider` label is the
+load-bearing one**: the provider-side reader `get_place_by_id!/1` MATCHes on
+`[:Provider, :Place]`, so it finds and projects your leaf back to its concrete type even
+though it lives in your own domain:
+
+```elixir
+Diffo.Provider.get_place_by_id!(tower.id)
+# => %MyApp.CellSite{type: :GeographicLocation, location: %Geo.Point{...}, ...}
+```
+
+`AshNeo4j.worlds/1` shows the underlying resolution — the node's labels project to the
+concrete `(domain, resource)`:
+
+```elixir
+AshNeo4j.worlds(tower)
+# => [{MyApp.Geo, MyApp.CellSite}]
+```
+
+Drop `Diffo.Provider.DomainFragment` from `MyApp.Geo` and the `Provider` label disappears —
+`get_place_by_id!` would no longer match the node. That fragment is precisely what opts your
+domain into the provider graph.
 
 ## Where to next
 

--- a/lib/diffo/provider/components/base_geographic_address.ex
+++ b/lib/diffo/provider/components/base_geographic_address.ex
@@ -4,7 +4,7 @@
 
 defmodule Diffo.Provider.BaseGeographicAddress do
   @moduledoc """
-  Ash Resource Fragment for TMF674 GeographicAddress — postal-address-style Place.
+  Ash Resource Fragment for TMF673 GeographicAddress — postal-address-style Place.
 
   Compose with `BasePlace` on a concrete leaf to get the TMF GeographicAddress
   attribute set (`street_name`, `street_nr`, `locality`, `state_or_province`,
@@ -45,7 +45,7 @@ defmodule Diffo.Provider.BaseGeographicAddress do
   - `country` — country (ISO 3166-1 alpha-2 code or full name; not constrained).
   - `postcode` — postcode.
 
-  ## Wire shape (TMF674)
+  ## Wire shape (TMF673)
 
   `jason.pick` selects base + address fields and renames to TMF camelCase
   (`streetName`, `streetNr`, `stateOrProvince`). Inherits BasePlace's

--- a/lib/diffo/provider/components/base_geographic_site.ex
+++ b/lib/diffo/provider/components/base_geographic_site.ex
@@ -4,7 +4,7 @@
 
 defmodule Diffo.Provider.BaseGeographicSite do
   @moduledoc """
-  Ash Resource Fragment for TMF675 GeographicSite — named-location-style Place
+  Ash Resource Fragment for TMF674 GeographicSite — named-location-style Place
   (exchange, office, branch, data centre, etc.).
 
   Compose with `BasePlace` on a concrete leaf to get the TMF GeographicSite
@@ -55,7 +55,7 @@ defmodule Diffo.Provider.BaseGeographicSite do
   Result is `nil` when `address_id` is unset; a concrete address struct when
   resolved; `%Diffo.Unknown{}` when the id is set but can't be projected.
 
-  ## Wire shape (TMF675)
+  ## Wire shape (TMF674)
 
   `jason.pick` selects base + site fields and renames to TMF camelCase
   (`siteType`, `siteCode`). Inherits BasePlace's `encode_geo_json/2` customize

--- a/lib/diffo/provider/components/base_place.ex
+++ b/lib/diffo/provider/components/base_place.ex
@@ -6,13 +6,13 @@ defmodule Diffo.Provider.BasePlace do
   @moduledoc """
   Ash Resource Fragment which is the foundation for TMF Place subtypes.
 
-  `BasePlace` is the foundation for the TMF675 cascade — Place is an abstract
-  TMF concept, and concrete subtype identity lives on the fragments that
-  compose with it:
+  `BasePlace` is the foundation for the TMF Place cascade (TMF673–675) — Place is
+  an abstract TMF concept, and concrete subtype identity lives on the fragments
+  that compose with it:
 
-    * `Diffo.Provider.BaseGeographicAddress` — TMF674 GeographicAddress fields
+    * `Diffo.Provider.BaseGeographicAddress` — TMF673 GeographicAddress fields
       (street_name, postcode, country, …)
-    * `Diffo.Provider.BaseGeographicSite` — TMF675 GeographicSite fields
+    * `Diffo.Provider.BaseGeographicSite` — TMF674 GeographicSite fields
       (site_type, site_code, projected :address ref)
     * `Diffo.Provider.BaseGeographicLocation` — TMF675 GeographicLocation
       fields (accuracy) and tightened geometry validation

--- a/lib/diffo/provider/components/place.ex
+++ b/lib/diffo/provider/components/place.ex
@@ -6,7 +6,7 @@ defmodule Diffo.Provider.Place do
   @moduledoc """
   Abstract Place reader — plumbing, not a TMF subtype recommendation.
 
-  TMF675 treats Place as abstract; the concrete subtypes are
+  TMF treats Place as abstract; the concrete subtypes are
   `Diffo.Provider.GeographicAddress`, `Diffo.Provider.GeographicSite`, and
   `Diffo.Provider.GeographicLocation`. Use those (or your own domain leaf
   composed from `BasePlace` + the matching `BaseGeographic*` fragment) for

--- a/lib/diffo/provider/geographic_address.ex
+++ b/lib/diffo/provider/geographic_address.ex
@@ -4,7 +4,7 @@
 
 defmodule Diffo.Provider.GeographicAddress do
   @moduledoc """
-  Ash Resource for a TMF674 GeographicAddress.
+  Ash Resource for a TMF673 GeographicAddress.
 
   Out-of-the-box concrete leaf derived from `BasePlace` + `BaseGeographicAddress`.
   Sets `type: :GeographicAddress` on the `:create` action; accepts the union of
@@ -28,7 +28,7 @@ defmodule Diffo.Provider.GeographicAddress do
     domain: Diffo.Provider
 
   resource do
-    description "An Ash Resource for a TMF674 GeographicAddress"
+    description "An Ash Resource for a TMF673 GeographicAddress"
     plural_name :geographic_addresses
   end
 

--- a/lib/diffo/provider/geographic_site.ex
+++ b/lib/diffo/provider/geographic_site.ex
@@ -4,7 +4,7 @@
 
 defmodule Diffo.Provider.GeographicSite do
   @moduledoc """
-  Ash Resource for a TMF675 GeographicSite.
+  Ash Resource for a TMF674 GeographicSite.
 
   Out-of-the-box concrete leaf derived from `BasePlace` + `BaseGeographicSite`.
   Sets `type: :GeographicSite` on the `:build` action; accepts the union of
@@ -27,7 +27,7 @@ defmodule Diffo.Provider.GeographicSite do
     domain: Diffo.Provider
 
   resource do
-    description "An Ash Resource for a TMF675 GeographicSite"
+    description "An Ash Resource for a TMF674 GeographicSite"
     plural_name :geographic_sites
   end
 

--- a/test/provider/place/cell_site_test.exs
+++ b/test/provider/place/cell_site_test.exs
@@ -4,9 +4,10 @@
 
 defmodule Diffo.Test.Place.CellSiteTest do
   @moduledoc """
-  Proves the graph-native spatial **expression calculations** on a GeographicLocation leaf
-  evaluate against the AshNeo4j sandbox — `distance_m` and `signal_strength`, both built on
-  AshNeo4j's `st_distance_in_meters`. Backs the `use_diffo_place_geo` livebook.
+  Proves the spatial + link-budget calculations on a GeographicLocation leaf evaluate
+  against the AshNeo4j sandbox: `distance_m` (a graph-native `st_distance_in_meters`
+  expression) and the free-space `path_loss_db` / `rssi_dbm` link budget. Backs the
+  `use_diffo_place_geo` livebook.
   """
   use ExUnit.Case, async: true
   @moduletag :domain_extended
@@ -21,6 +22,7 @@ defmodule Diffo.Test.Place.CellSiteTest do
   # Sydney CBD tower; Town Hall is ~513 m south-west.
   @tower_point %Geo.Point{coordinates: {151.2093, -33.8688}, srid: 4326}
   @town_hall %Geo.Point{coordinates: {151.2073, -33.8731}, srid: 4326}
+  @frequency_mhz 3500.0
 
   defp build_tower(attrs \\ %{}) do
     Nbn.build_cell_site!(
@@ -30,7 +32,8 @@ defmodule Diffo.Test.Place.CellSiteTest do
           name: "Sydney CBD Tower",
           location: @tower_point,
           technology: :FixedWireless,
-          transmit_power: 40.0
+          eirp_dbm: 60.0,
+          frequency_mhz: @frequency_mhz
         },
         attrs
       )
@@ -51,36 +54,73 @@ defmodule Diffo.Test.Place.CellSiteTest do
     end
   end
 
-  describe "signal_strength — power flux density from EIRP and distance" do
-    test "computes transmit_power / (4·π·d²) at the :at point" do
-      tower = build_tower() |> Ash.load!([signal_strength: %{at: @town_hall}], domain: Nbn)
+  describe "path_loss_db / rssi_dbm — free-space link budget" do
+    test "free-space path loss matches Friis at the :at point" do
+      tower =
+        build_tower()
+        |> Ash.load!([distance_m: %{at: @town_hall}, path_loss_db: %{at: @town_hall}],
+          domain: Nbn
+        )
 
-      # S = 40 W / (4π · 513²) ≈ 1.21e-5 W/m²
-      expected = 40.0 / (4 * :math.pi() * 513.0 * 513.0)
-      assert_in_delta tower.signal_strength, expected, 1.0e-7
+      expected = 20 * :math.log10(tower.distance_m) + 20 * :math.log10(@frequency_mhz) - 27.55
+      assert_in_delta tower.path_loss_db, expected, 0.2
     end
 
-    test "halving transmit power halves the signal strength at the same point" do
-      full = build_tower() |> Ash.load!([signal_strength: %{at: @town_hall}], domain: Nbn)
+    test "rssi is eirp minus path loss (isotropic Rx)" do
+      tower =
+        build_tower()
+        |> Ash.load!([path_loss_db: %{at: @town_hall}, rssi_dbm: %{at: @town_hall}], domain: Nbn)
 
-      half =
-        build_tower(%{id: "CELL-SYD-2", transmit_power: 20.0})
-        |> Ash.load!([signal_strength: %{at: @town_hall}], domain: Nbn)
+      assert_in_delta tower.rssi_dbm, 60.0 - tower.path_loss_db, 0.2
+    end
 
-      assert_in_delta half.signal_strength, full.signal_strength / 2, 1.0e-9
+    test "+6 dB EIRP lifts RSSI by 6 dB at the same point" do
+      base = build_tower() |> Ash.load!([rssi_dbm: %{at: @town_hall}], domain: Nbn)
+
+      hotter =
+        build_tower(%{id: "CELL-SYD-2", eirp_dbm: 66.0})
+        |> Ash.load!([rssi_dbm: %{at: @town_hall}], domain: Nbn)
+
+      assert_in_delta hotter.rssi_dbm, base.rssi_dbm + 6.0, 0.2
     end
   end
 
-  describe "both calculations loaded together" do
-    test "distance_m and signal_strength load in one pass" do
+  describe "all calculations loaded together" do
+    test "distance_m, path_loss_db and rssi_dbm load in one pass" do
       tower =
         build_tower()
-        |> Ash.load!([distance_m: %{at: @town_hall}, signal_strength: %{at: @town_hall}],
+        |> Ash.load!(
+          [
+            distance_m: %{at: @town_hall},
+            path_loss_db: %{at: @town_hall},
+            rssi_dbm: %{at: @town_hall}
+          ],
           domain: Nbn
         )
 
       assert is_float(tower.distance_m)
-      assert is_float(tower.signal_strength)
+      assert is_float(tower.path_loss_db)
+      assert is_float(tower.rssi_dbm)
+    end
+  end
+
+  describe "cross-world projection" do
+    test "worlds/1 projects the CellSite node back to its concrete leaf" do
+      # Node labels are [Nbn, CellSite, Place, Provider] — no GeographicLocation label
+      # (subtype identity is the module + :type property); the :Provider label comes from
+      # Nbn composing Diffo.Provider.DomainFragment. worlds/1 recovers the concrete
+      # (domain, resource) by label-subset match.
+      tower = build_tower()
+      assert {Nbn, Diffo.Test.Place.CellSite} in AshNeo4j.worlds(tower)
+    end
+
+    test "Diffo.Provider.get_place_by_id! projects across domains via the :Provider label" do
+      # The provider-side reader MATCHes [:Provider, :Place]; the :Provider label (from the
+      # domain fragment) is what lets it find and project a leaf in another domain.
+      tower = build_tower()
+
+      assert %Diffo.Test.Place.CellSite{type: :GeographicLocation} =
+               Diffo.Provider.get_place_by_id!(tower.id)
     end
   end
 end

--- a/test/support/resource/place/cell_site.ex
+++ b/test/support/resource/place/cell_site.ex
@@ -2,17 +2,71 @@
 #
 # SPDX-License-Identifier: MIT
 
+defmodule Diffo.Test.Rf do
+  @moduledoc """
+  Free-space (Friis) link-budget calculation for a Point-located site.
+
+  `metric: :path_loss_db` — free-space path loss to the `:at` point;
+  `metric: :rssi_dbm` — isotropic received power, `eirp_dbm − path_loss_db`.
+
+  Distance uses `AshNeo4j.Geo.haversine_meters/2` so it matches Neo4j's WGS-84
+  `point.distance` model (the same value the `distance_m` expression returns). dB math
+  needs `log10`, which `Ash.Expr` doesn't provide, so this is an Elixir calculation rather
+  than a graph expression.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, opts, _context) do
+    case opts[:metric] do
+      :rssi_dbm -> [:location, :eirp_dbm, :frequency_mhz]
+      :path_loss_db -> [:location, :frequency_mhz]
+    end
+  end
+
+  @impl true
+  def calculate(records, opts, context) do
+    %Geo.Point{coordinates: at} = context.arguments.at
+    Enum.map(records, &compute(opts[:metric], &1, at))
+  end
+
+  defp compute(:path_loss_db, %{location: %Geo.Point{coordinates: site}, frequency_mhz: f}, at)
+       when is_number(f) do
+    fspl_db(AshNeo4j.Geo.haversine_meters(site, at), f)
+  end
+
+  defp compute(
+         :rssi_dbm,
+         %{location: %Geo.Point{coordinates: site}, eirp_dbm: eirp, frequency_mhz: f},
+         at
+       )
+       when is_number(eirp) and is_number(f) do
+    Float.round(eirp - fspl_db(AshNeo4j.Geo.haversine_meters(site, at), f), 1)
+  end
+
+  defp compute(_metric, _record, _at), do: nil
+
+  # Friis free-space path loss; d in metres, f in MHz. Line-of-sight floor.
+  defp fspl_db(+0.0, _f), do: 0.0
+
+  defp fspl_db(d_m, f_mhz) do
+    Float.round(20 * :math.log10(d_m) + 20 * :math.log10(f_mhz) - 27.55, 1)
+  end
+end
+
 defmodule Diffo.Test.Place.CellSite do
   @moduledoc """
   Test fixture for the `use_diffo_place_geo` livebook — a `GeographicLocation` leaf
-  (`BasePlace` + `BaseGeographicLocation`) carrying `transmit_power` and two **expression
-  calculations** built on AshNeo4j's graph-native `st_distance_in_meters`:
+  (`BasePlace` + `BaseGeographicLocation`) carrying an `eirp_dbm` / `frequency_mhz` and
+  three calculations:
 
-    * `distance_m` — geodesic distance to a given `:at` point.
-    * `signal_strength` — power flux density (W/m²) `transmit_power / (4·π·d²)`.
+    * `distance_m` — geodesic distance to a given `:at` point (a graph-native
+      `st_distance_in_meters` expression, pushing to Neo4j `point.distance`).
+    * `path_loss_db` / `rssi_dbm` — free-space link budget (`Diffo.Test.Rf`); dB math is an
+      Elixir calculation because `log10` isn't an `Ash.Expr` function.
 
-  Exercised by `inherited_characteristic`-unrelated `cell_site_test.exs` to prove the
-  spatial expressions evaluate against the AshNeo4j sandbox.
+  Exercised by `cell_site_test.exs` to prove both the spatial expression and the link-budget
+  calcs evaluate against the AshNeo4j sandbox.
   """
   alias Diffo.Provider.BasePlace
   alias Diffo.Provider.BaseGeographicLocation
@@ -23,7 +77,7 @@ defmodule Diffo.Test.Place.CellSite do
     domain: Nbn
 
   resource do
-    description "A test cell site (GeographicLocation) with spatial calculations"
+    description "A test cell site (GeographicLocation) with spatial + link-budget calculations"
     plural_name :cell_sites
   end
 
@@ -38,7 +92,8 @@ defmodule Diffo.Test.Place.CellSite do
         :accuracy,
         :cell_id,
         :technology,
-        :transmit_power
+        :eirp_dbm,
+        :frequency_mhz
       ]
 
       change set_attribute(:type, :GeographicLocation)
@@ -55,8 +110,14 @@ defmodule Diffo.Test.Place.CellSite do
       constraints one_of: [:FixedWireless, :Mobile4G, :Mobile5G]
     end
 
-    # equivalent isotropically radiated power, in watts
-    attribute :transmit_power, :float, public?: true
+    # equivalent isotropically radiated power, in dBm (folds in the Tx antenna gain)
+    attribute :eirp_dbm, :float, public?: true
+
+    attribute :frequency_mhz, :float do
+      description "carrier frequency in MHz (drives free-space path loss)"
+      public? true
+      default 3500.0
+    end
   end
 
   calculations do
@@ -68,15 +129,16 @@ defmodule Diffo.Test.Place.CellSite do
       end
     end
 
-    # signal strength (power flux density, W/m²) from EIRP and that distance
-    calculate :signal_strength,
-              :float,
-              expr(
-                transmit_power /
-                  (4 * 3.141592653589793 *
-                     st_distance_in_meters(location, ^arg(:at)) *
-                     st_distance_in_meters(location, ^arg(:at)))
-              ) do
+    # free-space path loss (dB) to the :at point
+    calculate :path_loss_db, :float, {Diffo.Test.Rf, metric: :path_loss_db} do
+      argument :at, AshGeo.GeoJson do
+        constraints geo_types: [:point], force_srid: 4326
+        allow_nil? false
+      end
+    end
+
+    # received signal level (dBm), isotropic Rx: eirp_dbm − path_loss_db
+    calculate :rssi_dbm, :float, {Diffo.Test.Rf, metric: :rssi_dbm} do
       argument :at, AshGeo.GeoJson do
         constraints geo_types: [:point], force_srid: 4326
         allow_nil? false

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -100,10 +100,10 @@ end
 abstract reader that `get_instance_by_id!/1` projects through. A service
 **terminates** or **cancels** — only a Specification retires.
 
-### Place subtype fragments (TMF675 cascade)
+### Place subtype fragments (TMF Place cascade)
 
-`BasePlace` composes with one of three subtype fragments to produce a TMF675
-concrete Place. Diffo ships the three subtype leaves out of the box and the
+`BasePlace` composes with one of three subtype fragments to produce a concrete
+TMF Place (TMF673 GeographicAddress, TMF674 GeographicSite, TMF675 GeographicLocation). Diffo ships the three subtype leaves out of the box and the
 matching consumer leaf is a sibling, not a child:
 
 | Subtype | Subtype fragment | Concrete leaf in diffo |


### PR DESCRIPTION
… budget (#217)

- TMF numbering: GeographicAddress -> TMF673, GeographicSite -> TMF674 (were 674/675); GeographicLocation = TMF675 unchanged; generalise the TMF675-cascade phrasings.
- place livebook: MyApp.Geo composes Diffo.Provider.DomainFragment (the :Provider label) so get_place_by_id! projects the custom CellSite leaf; allow_unregistered? true so the CellSite cell runs; add a 'Projecting a custom leaf' section.
- CellSite RF model reworked to a free-space (Friis) link budget in dBm: eirp_dbm + frequency_mhz; distance_m (graph expression) + path_loss_db + rssi_dbm (Elixir calc, since log10 isn't in Ash.Expr). Replaces the W/m2 power-density model.
- cell_site_test: distance, FSPL/RSSI link budget, and worlds/1 + get_place_by_id! projection all asserted (8/8).