### PR TITLE
feat: require :Provider label on provider resources (compile-time guard, #219)

### DIFF
--- a/lib/diffo/provider/domain_fragment.ex
+++ b/lib/diffo/provider/domain_fragment.ex
@@ -22,6 +22,11 @@ defmodule Diffo.Provider.DomainFragment do
         use Ash.Domain, fragments: [Diffo.Provider.DomainFragment]
         ...
       end
+
+  Forgetting this is a silent footgun (no `:Provider` label → projection and ref
+  resolution quietly fail), so `Diffo.Provider.Extension.Verifiers.VerifyProviderDomain`
+  enforces it at compile time: a provider resource whose domain emits no `:Provider`
+  label fails to compile with a message pointing here.
   """
   use Spark.Dsl.Fragment,
     of: Ash.Domain,

--- a/lib/diffo/provider/extension.ex
+++ b/lib/diffo/provider/extension.ex
@@ -721,6 +721,7 @@ defmodule Diffo.Provider.Extension do
       Diffo.Provider.Extension.Verifiers.VerifyPlaces,
       Diffo.Provider.Extension.Verifiers.VerifyInstances,
       Diffo.Provider.Extension.Verifiers.VerifyBehaviour,
-      Diffo.Provider.Extension.Verifiers.VerifyRelationships
+      Diffo.Provider.Extension.Verifiers.VerifyRelationships,
+      Diffo.Provider.Extension.Verifiers.VerifyProviderDomain
     ]
 end

--- a/lib/diffo/provider/extension/verifiers/verify_provider_domain.ex
+++ b/lib/diffo/provider/extension/verifiers/verify_provider_domain.ex
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 diffo contributors <https://github.com/diffo-dev/diffo/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Diffo.Provider.Extension.Verifiers.VerifyProviderDomain do
+  @moduledoc """
+  Verifies that a provider resource (Instance / Party / Place — anything composing
+  `Diffo.Provider.Extension`) carries the `:Provider` Neo4j label.
+
+  `:Provider` is what makes provider polymorphism work: cross-world projection
+  (`Diffo.Provider.get_*_by_id!/1`, `AshNeo4j.worlds/1`) and `PlaceRef` / `PartyRef` /
+  `belongs_to` resolution all MATCH on `[:Provider, <base-type>]`. A node gets `:Provider`
+  either because its domain *is* `Diffo.Provider` (the built-in leaves — `:Provider` is
+  their `domain_label`) or because its domain composes `Diffo.Provider.DomainFragment`
+  (which writes `:Provider` as the domain-fragment label).
+
+  Forget the fragment on a consumer domain and the node simply lacks `:Provider`: provider
+  readers stop finding it and projection **silently** returns nothing. This verifier turns
+  that silent footgun into a compile-time error pointing at the fix.
+
+  ## Resolution (and why it isn't the persisted `:all_labels`)
+
+  We can't trust the `:all_labels` AshNeo4j persists, because its domain-fragment slot is
+  resolved with `Code.ensure_loaded?` at compile time — if the domain hasn't loaded yet
+  (resource/domain compile order), it bakes a `nil` fragment label even though the node
+  *does* get `:Provider` at runtime (where `domain_fragment_label/1` falls back to the
+  domain). So we resolve the domain ourselves:
+
+    * `domain_label == :Provider` → fine (built-in / `Diffo.Provider` domain).
+    * otherwise resolve the domain (compiling it if needed) and check it emits `:Provider`
+      via `AshNeo4j.DataLayer.Domain.Info.neo4j_label/1`.
+
+  If the domain genuinely can't be resolved at this point in compilation, we **stay silent**
+  — a best-effort guard never false-positives on a resource that may be correct at runtime.
+  In practice the domain is available by the time a consumer's resource compiles, so the
+  forgotten-fragment case is caught.
+  """
+  use Spark.Dsl.Verifier
+
+  alias Spark.Dsl.Verifier
+  alias Spark.Error.DslError
+
+  @impl true
+  def verify(dsl_state) do
+    if provider_label?(dsl_state) do
+      :ok
+    else
+      {:error, missing_provider_error(dsl_state)}
+    end
+  end
+
+  # True when the node will carry :Provider — or when we can't determine it (don't
+  # false-positive). False only when we can confirm the domain emits no :Provider label.
+  defp provider_label?(dsl_state) do
+    if Verifier.get_persisted(dsl_state, :domain_label) == :Provider do
+      true
+    else
+      domain = Verifier.get_persisted(dsl_state, :domain)
+
+      with true <- is_atom(domain) and not is_nil(domain),
+           {:module, ^domain} <- Code.ensure_compiled(domain),
+           true <- function_exported?(domain, :spark_dsl_config, 0) do
+        AshNeo4j.DataLayer.Domain.Info.neo4j_label(domain) == {:ok, :Provider}
+      else
+        # Domain unresolvable here (not loadable / compile cycle) — can't confirm a
+        # problem, so don't raise.
+        _ -> true
+      end
+    end
+  end
+
+  defp missing_provider_error(dsl_state) do
+    resource = Verifier.get_persisted(dsl_state, :module)
+    domain = Verifier.get_persisted(dsl_state, :domain)
+
+    DslError.exception(
+      module: resource,
+      path: [:provider],
+      message:
+        "provider: #{inspect(resource)} does not carry the :Provider Neo4j label, so it can't " <>
+          "participate in provider polymorphism (cross-world projection, and PlaceRef / " <>
+          "PartyRef / belongs_to resolution, all MATCH on :Provider). Its domain " <>
+          "#{inspect(domain)} must compose Diffo.Provider.DomainFragment:\n\n" <>
+          "    use Ash.Domain, fragments: [Diffo.Provider.DomainFragment]"
+    )
+  end
+end

--- a/test/provider/extension/verify_provider_domain_test.exs
+++ b/test/provider/extension/verify_provider_domain_test.exs
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 diffo contributors <https://github.com/diffo-dev/diffo/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Diffo.Provider.Extension.VerifyProviderDomainTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  @moduletag :domain_extended
+  import ExUnit.CaptureIO
+  alias Diffo.Test.Util
+
+  describe "VerifyProviderDomain (#219)" do
+    # A provider leaf whose domain does NOT compose Diffo.Provider.DomainFragment lacks the
+    # :Provider label, so it can't be projected/resolved. Catch it at compile time instead
+    # of failing silently at runtime.
+    test "a provider leaf in a fragment-less domain warns DslError on compilation" do
+      Util.assert_compile_time_warning(
+        Spark.Error.DslError,
+        "does not carry the :Provider Neo4j label",
+        fn ->
+          defmodule NoProviderDomain do
+            use Ash.Domain, otp_app: :diffo, validate_config_inclusion?: false
+
+            resources do
+              allow_unregistered?(true)
+            end
+          end
+
+          defmodule PlaceWithoutProvider do
+            use Ash.Resource, fragments: [Diffo.Provider.BasePlace], domain: NoProviderDomain
+
+            resource do
+              description "place in a domain lacking Diffo.Provider.DomainFragment"
+            end
+
+            jason do
+              pick [:id, :type]
+              rename type: "@type"
+            end
+
+            outstanding do
+              expect [:id, :type]
+            end
+
+            actions do
+              create :build do
+                accept [:id, :name]
+                change set_attribute(:type, :GeographicSite)
+              end
+            end
+          end
+        end
+      )
+    end
+
+    # The same leaf in a domain that DOES compose the fragment carries :Provider and
+    # compiles cleanly — no projection footgun, no error.
+    test "a provider leaf in a domain composing DomainFragment compiles without the error" do
+      output =
+        capture_io(:stderr, fn ->
+          defmodule ProviderDomain do
+            use Ash.Domain,
+              otp_app: :diffo,
+              validate_config_inclusion?: false,
+              fragments: [Diffo.Provider.DomainFragment]
+
+            resources do
+              allow_unregistered?(true)
+            end
+          end
+
+          defmodule PlaceWithProvider do
+            use Ash.Resource, fragments: [Diffo.Provider.BasePlace], domain: ProviderDomain
+
+            resource do
+              description "place in a domain composing Diffo.Provider.DomainFragment"
+            end
+
+            jason do
+              pick [:id, :type]
+              rename type: "@type"
+            end
+
+            outstanding do
+              expect [:id, :type]
+            end
+
+            actions do
+              create :build do
+                accept [:id, :name]
+                change set_attribute(:type, :GeographicSite)
+              end
+            end
+          end
+        end)
+
+      refute output =~ "does not carry the :Provider Neo4j label"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #219. Turns the silent 'forgot Diffo.Provider.DomainFragment' footgun into a compile error (VerifyProviderDomain). Resolves the domain via ensure_compiled rather than persisted :all_labels (which can carry a stale nil fragment label from compile ordering — false-positived on Carrier); never false-positives. Tests cover both paths; full suite green.