### PR TITLE
fix: relationship-hop traversal walks general Relationship too (#222)

### DIFF
--- a/lib/diffo/provider/components/calculations/field_via_relationship.ex
+++ b/lib/diffo/provider/components/calculations/field_via_relationship.ex
@@ -4,12 +4,15 @@
 
 defmodule Diffo.Provider.Calculations.FieldViaRelationship do
   @moduledoc """
-  Reads a field from target instances reached via `DefinedSimpleRelationship`.
+  Reads a field from target instances reached via a forward relationship edge.
 
-  Traverses `DefinedSimpleRelationship` in the forward direction — filtering by
-  `source_id = current.id` — and returns the named field from each resolved target
-  instance. Both `type:` and `alias:` are optional filters; when omitted they match
-  any value on that dimension.
+  Traverses both relationship resources — `DefinedSimpleRelationship` (a single
+  characteristic closed at creation) and the general `Relationship` (mutable
+  characteristics) — in the forward direction (filtering by `source_id = current.id`) and
+  returns the named field from each resolved target instance. An edge is one or the other;
+  this calc spans both so a consumer needn't know which storage the `:relate` action chose
+  (#222). Both `type:` and `alias:` are optional filters; when omitted they match any value
+  on that dimension.
 
   ## Options
 
@@ -20,10 +23,9 @@ defmodule Diffo.Provider.Calculations.FieldViaRelationship do
   - `type:` *(optional)* — atom matching the `type` attribute on the relationship
     (e.g. `:assignedTo`, `:reliesOn`). When omitted, all types are included.
 
-  Providing neither filter returns fields from every forward `DefinedSimpleRelationship`
-  on this instance. In practice at least one of `alias:` or `type:` should be supplied,
-  since a source instance typically has many forward relationships pointing to unrelated
-  things.
+  Providing neither filter returns fields from every forward relationship on this instance.
+  In practice at least one of `alias:` or `type:` should be supplied, since a source
+  instance typically has many forward relationships pointing to unrelated things.
 
   ## Examples
 
@@ -38,29 +40,39 @@ defmodule Diffo.Provider.Calculations.FieldViaRelationship do
   """
   use Ash.Resource.Calculation
 
+  alias Diffo.Provider.DefinedSimpleRelationship
+  alias Diffo.Provider.Relationship
+
   @impl true
   def load(_query, _opts, _context), do: []
 
   @impl true
   def calculate(records, opts, _context) do
-    alias_name = opts[:alias]
-    type = opts[:type]
     field = opts[:field]
 
     Enum.map(records, fn record ->
-      filter = [source_id: record.id]
-      filter = if type, do: Keyword.put(filter, :type, type), else: filter
-      filter = if alias_name, do: Keyword.put(filter, :alias, alias_name), else: filter
+      filter =
+        [source_id: record.id]
+        |> maybe_put(:type, opts[:type])
+        |> maybe_put(:alias, opts[:alias])
 
-      Diffo.Provider.DefinedSimpleRelationship
-      |> Ash.Query.filter_input(filter)
-      |> Ash.read!(domain: Diffo.Provider)
-      |> Enum.flat_map(fn rel ->
-        Diffo.Provider.Instance
-        |> Ash.Query.filter_input(id: rel.target_id)
-        |> Ash.read!(domain: Diffo.Provider)
-        |> Enum.map(&Map.get(&1, field))
-      end)
+      target_fields(DefinedSimpleRelationship, filter, field) ++
+        target_fields(Relationship, filter, field)
     end)
   end
+
+  defp target_fields(resource, filter, field) do
+    resource
+    |> Ash.Query.filter_input(filter)
+    |> Ash.read!(domain: Diffo.Provider)
+    |> Enum.flat_map(fn rel ->
+      Diffo.Provider.Instance
+      |> Ash.Query.filter_input(id: rel.target_id)
+      |> Ash.read!(domain: Diffo.Provider)
+      |> Enum.map(&Map.get(&1, field))
+    end)
+  end
+
+  defp maybe_put(filter, _key, nil), do: filter
+  defp maybe_put(filter, key, value), do: Keyword.put(filter, key, value)
 end

--- a/lib/diffo/provider/components/calculations/traversal.ex
+++ b/lib/diffo/provider/components/calculations/traversal.ex
@@ -11,10 +11,11 @@ defmodule Diffo.Provider.Calculations.Traversal do
   - `:forward` — filter `source_id` in the current ids, collect `target_id`s.
   - `:reverse` — filter `target_id` in the current ids, collect `source_id`s.
 
-  over `AssignmentRelationship` (`:assignment` hops) or `DefinedSimpleRelationship`
-  (`:relationship` hops). A hop may fan out (reach many instances) or fan in (several
-  intermediates reach the same instance); ids are de-duplicated between hops so a node
-  reached by multiple paths is visited once.
+  over `AssignmentRelationship` (`:assignment` hops) or — for `:relationship` hops — **both**
+  `DefinedSimpleRelationship` and the general `Relationship` (#222), since an edge is stored
+  as one or the other and traversal is meaningful over either. A hop may fan out (reach many
+  instances) or fan in (several intermediates reach the same instance); ids are de-duplicated
+  between hops so a node reached by multiple paths is visited once.
 
   Hops are the canonical form produced by `Diffo.Provider.Extension.Traversal.normalize/2`:
   `{:forward | :reverse, :assignment | :relationship, selector}`. Built so
@@ -22,6 +23,7 @@ defmodule Diffo.Provider.Calculations.Traversal do
   """
   alias Diffo.Provider.AssignmentRelationship
   alias Diffo.Provider.DefinedSimpleRelationship
+  alias Diffo.Provider.Relationship
 
   @doc """
   Walks `hops` from `start_id`, returning the de-duplicated list of final instance ids.
@@ -39,8 +41,17 @@ defmodule Diffo.Provider.Calculations.Traversal do
   defp step({direction, :assignment, %{alias: alias}}, id),
     do: edge_ids(AssignmentRelationship, direction, id, alias_filter(alias))
 
-  defp step({direction, :relationship, %{type: type, alias: alias}}, id),
-    do: edge_ids(DefinedSimpleRelationship, direction, id, relationship_filter(type, alias))
+  # A `relationship:` hop spans **both** relationship resources (#222). An edge is one or
+  # the other — `DefinedSimpleRelationship` (a single characteristic closed at creation) or
+  # the general `Relationship` (mutable characteristics) — and "what do I contain / own /
+  # relate to" is equally meaningful over either, so the consumer needn't know which storage
+  # the `:relate` action chose. Ids are de-duplicated by `walk/2`.
+  defp step({direction, :relationship, %{type: type, alias: alias}}, id) do
+    filter = relationship_filter(type, alias)
+
+    edge_ids(DefinedSimpleRelationship, direction, id, filter) ++
+      edge_ids(Relationship, direction, id, filter)
+  end
 
   defp edge_ids(resource, :forward, id, filter) do
     resource

--- a/lib/diffo/provider/extension/traversal.ex
+++ b/lib/diffo/provider/extension/traversal.ex
@@ -15,9 +15,10 @@ defmodule Diffo.Provider.Extension.Traversal do
   - `:reverse` — this instance is the edge `target`; filter `target_id = me`, follow to
     `source_id`.
 
-  Mechanism is `:assignment` (`AssignmentRelationship`) or `:relationship`
-  (`DefinedSimpleRelationship`). The two axes are independent, so any
-  mechanism × direction combination is a legal hop and chains of any length compose.
+  Mechanism is `:assignment` (`AssignmentRelationship`) or `:relationship` (both
+  `DefinedSimpleRelationship` and the general `Relationship` — a `:relationship` hop spans
+  either storage, #222). The two axes are independent, so any mechanism × direction
+  combination is a legal hop and chains of any length compose.
 
   ## User hop forms
 

--- a/lib/diffo/provider/extension/verifiers/verify_provider_domain.ex
+++ b/lib/diffo/provider/extension/verifiers/verify_provider_domain.ex
@@ -8,7 +8,7 @@ defmodule Diffo.Provider.Extension.Verifiers.VerifyProviderDomain do
   `Diffo.Provider.Extension`) carries the `:Provider` Neo4j label.
 
   `:Provider` is what makes provider polymorphism work: cross-world projection
-  (`Diffo.Provider.get_*_by_id!/1`, `AshNeo4j.worlds/1`) and `PlaceRef` / `PartyRef` /
+  (`Diffo.Provider.get_place_by_id!/1` and friends, `AshNeo4j.worlds/1`) and `PlaceRef` / `PartyRef` /
   `belongs_to` resolution all MATCH on `[:Provider, <base-type>]`. A node gets `:Provider`
   either because its domain *is* `Diffo.Provider` (the built-in leaves — `:Provider` is
   their `domain_label`) or because its domain composes `Diffo.Provider.DomainFragment`

--- a/test/provider/extension/field_via_relationship_test.exs
+++ b/test/provider/extension/field_via_relationship_test.exs
@@ -90,4 +90,23 @@ defmodule Diffo.Provider.Extension.FieldViaRelationshipTest do
       assert shelf.assigned_linked_name == ["target-a"]
     end
   end
+
+  describe "FieldViaRelationship — general Relationship (#222)" do
+    test "reads field from a target reached via a general Relationship, not just DSR" do
+      {:ok, shelf} = Parties.build_shelf_with_installer()
+      {:ok, card} = Servo.build_card(%{name: "rel-target"})
+
+      # general Relationship (mutable), as the standard :relate action creates
+      Diffo.Provider.create_relationship!(%{
+        type: :assignedTo,
+        alias: :link,
+        source_id: shelf.id,
+        target_id: card.id
+      })
+
+      shelf = Ash.load!(shelf, [:linked_target_name], domain: Servo)
+
+      assert shelf.linked_target_name == ["rel-target"]
+    end
+  end
 end

--- a/test/provider/extension/inherited_characteristic_traversal_test.exs
+++ b/test/provider/extension/inherited_characteristic_traversal_test.exs
@@ -40,6 +40,24 @@ defmodule Diffo.Provider.Extension.InheritedCharacteristicTraversalTest do
                Enum.sort([c1.id, c2.id])
     end
 
+    test "contained_cards also follows a general Relationship :contains edge (#222)" do
+      # The standard :relate action stores a mutable Diffo.Provider.Relationship, not a
+      # DefinedSimpleRelationship — a relationship: hop must still reach it.
+      probe = probe!()
+      card = defined_card!("rel-card")
+
+      Diffo.Provider.create_relationship!(%{
+        type: :contains,
+        source_id: probe.id,
+        target_id: card.id
+      })
+
+      probe = Ash.load!(probe, [:contained_cards], domain: Servo)
+
+      assert [%CardCharacteristic{instance_id: instance_id}] = probe.contained_cards
+      assert instance_id == card.id
+    end
+
     test "owned_card collapses the single card owned via :circuit to a raw record" do
       probe = probe!()
       card = defined_card!("owned")

--- a/test/provider/extension/traversal_test.exs
+++ b/test/provider/extension/traversal_test.exs
@@ -118,6 +118,45 @@ defmodule Diffo.Provider.Extension.TraversalTest do
       assert Walk.walk(card.id, [{:reverse, :relationship, %{type: :contains, alias: nil}}]) ==
                [shelf.id]
     end
+
+    test "a relationship hop also walks the general Relationship, not just DSR (#222)" do
+      {:ok, group} = Diffo.Test.Parties.build_shelf_with_installer()
+      {:ok, nni} = Servo.build_card(%{})
+
+      # general Relationship (mutable) — what the standard :relate action creates
+      Diffo.Provider.create_relationship!(%{
+        type: :contains,
+        source_id: group.id,
+        target_id: nni.id
+      })
+
+      assert Walk.walk(group.id, [{:forward, :relationship, %{type: :contains, alias: nil}}]) ==
+               [nni.id]
+
+      assert Walk.walk(nni.id, [{:reverse, :relationship, %{type: :contains, alias: nil}}]) ==
+               [group.id]
+    end
+
+    test "a relationship hop unions DefinedSimpleRelationship and Relationship edges (#222)" do
+      {:ok, group} = Diffo.Test.Parties.build_shelf_with_installer()
+      {:ok, dsr_card} = Servo.build_card(%{})
+      {:ok, rel_card} = Servo.build_card(%{})
+
+      Diffo.Provider.create_defined_simple_relationship!(%{
+        type: :contains,
+        source_id: group.id,
+        target_id: dsr_card.id
+      })
+
+      Diffo.Provider.create_relationship!(%{
+        type: :contains,
+        source_id: group.id,
+        target_id: rel_card.id
+      })
+
+      assert Walk.walk(group.id, [{:forward, :relationship, %{type: :contains, alias: nil}}])
+             |> Enum.sort() == Enum.sort([dsr_card.id, rel_card.id])
+    end
   end
 
   defp shelf_with_two_assigned_cards do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -828,8 +828,11 @@ is mechanical and matches the stored edge:
   `source`).
 
 Mechanism is `assignment:` (`AssignmentRelationship`, keyed by `alias`) or `relationship:`
-(`DefinedSimpleRelationship`, by `type` and/or `alias`). The two axes are independent, so
-any combination is a legal hop and chains of any length compose:
+(by `type` and/or `alias`). A `relationship:` hop spans **both** relationship resources —
+`DefinedSimpleRelationship` (a single characteristic closed at creation) and the general
+`Relationship` (mutable characteristics) — so an edge created by the standard `:relate`
+action is reachable either way. The two axes are independent, so any combination is a legal
+hop and chains of any length compose:
 
 | direction | `assignment` | `relationship` |
 |---|---|---|
@@ -948,8 +951,9 @@ Options: `field:` (required), `via:` (optional list of alias steps — omit for 
 
 ### `FieldViaRelationship`
 
-Traverses `DefinedSimpleRelationship` in the forward direction (source → target) filtered
-by `alias:` and/or `type:`, and reads a field from each target instance.
+Traverses relationship edges in the forward direction (source → target) filtered by
+`alias:` and/or `type:`, and reads a field from each target instance. Spans both
+`DefinedSimpleRelationship` and the general `Relationship` (#222).
 
 ```elixir
 # Name of the target reached via the :provides alias


### PR DESCRIPTION
Fixes #222. The :relationship hop (and FieldViaRelationship) now span both DefinedSimpleRelationship and the general Relationship, so an edge created by the standard :relate action is reachable. Deduped by walk/2; docs + tests updated; full suite green.