### PR TITLE
feat: via: traversal for inherited_place / inherited_party (#226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, add `diffo` to your list of dependencies in `mix.exs` manually:
 ```elixir
 def deps do
   [
-    {:diffo, "~> 0.6.0"}
+    {:diffo, "~> 0.8.0"}
   ]
 end
 ```

--- a/diffo.livemd
+++ b/diffo.livemd
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.6.0"}
+    {:diffo, "~> 0.8.0"}
   ],
   consolidate_protocols: false
 )

--- a/documentation/dsls/DSL-Diffo.Provider.Extension.md
+++ b/documentation/dsls/DSL-Diffo.Provider.Extension.md
@@ -534,7 +534,7 @@ inherited_party role
 ```
 
 
-Declares a party derived by traversing the assignment graph — generates a calculation, no PartyRef node created
+Declares a party derived by walking the instance graph along a via: hop chain then reading a PartyRef at source_role — generates a calculation, no PartyRef node created
 
 
 
@@ -544,13 +544,14 @@ Declares a party derived by traversing the assignment graph — generates a calc
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`role`](#provider-parties-inherited_party-role){: #provider-parties-inherited_party-role .spark-required} | `atom` |  | The role name — also the default alias to follow on AssignmentRelationship. |
+| [`role`](#provider-parties-inherited_party-role){: #provider-parties-inherited_party-role .spark-required} | `atom` |  | The generated calc name and surfaced PartyRef role; default single hop alias. |
 ### Options
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`source_role`](#provider-parties-inherited_party-source_role){: #provider-parties-inherited_party-source_role .spark-required} | `atom` |  | The PartyRef role to pick up on the arrived-at instance. |
-| [`via`](#provider-parties-inherited_party-via){: #provider-parties-inherited_party-via } | `list(atom)` |  | Sequence of assignment aliases to traverse. Defaults to [role] for single-hop. Use a list for multi-level. |
+| [`source_role`](#provider-parties-inherited_party-source_role){: #provider-parties-inherited_party-source_role .spark-required} | `atom` |  | The PartyRef role to read on the reached instance (terminal deref, not a via: hop). |
+| [`via`](#provider-parties-inherited_party-via){: #provider-parties-inherited_party-via } | `list(any)` |  | Hop chain to the instance holding the ref (unified #213 grammar). Bare atom = {:reverse, assignment: alias}; tuples are {:forward\|:reverse, assignment: alias} or {:forward\|:reverse, relationship: type\|[type:, alias:]}. Defaults to [role]. |
+| [`collapse`](#provider-parties-inherited_party-collapse){: #provider-parties-inherited_party-collapse } | `:first \| :last` |  | Collapses the result list (refs at source_role across reached instances) to that end; the calc then returns a single party or nil. |
 
 
 
@@ -723,7 +724,7 @@ inherited_place role
 ```
 
 
-Declares a place derived by traversing the assignment graph — generates a calculation, no PlaceRef node created
+Declares a place derived by walking the instance graph along a via: hop chain then reading a PlaceRef at source_role — generates a calculation, no PlaceRef node created
 
 
 
@@ -733,13 +734,14 @@ Declares a place derived by traversing the assignment graph — generates a calc
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`role`](#provider-places-inherited_place-role){: #provider-places-inherited_place-role .spark-required} | `atom` |  | The role name — also the default alias to follow on AssignmentRelationship. |
+| [`role`](#provider-places-inherited_place-role){: #provider-places-inherited_place-role .spark-required} | `atom` |  | The generated calc name and surfaced PlaceRef role; default single hop alias. |
 ### Options
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`source_role`](#provider-places-inherited_place-source_role){: #provider-places-inherited_place-source_role .spark-required} | `atom` |  | The PlaceRef role to pick up on the arrived-at instance. |
-| [`via`](#provider-places-inherited_place-via){: #provider-places-inherited_place-via } | `list(atom)` |  | Sequence of assignment aliases to traverse. Defaults to [role] for single-hop. Use a list for multi-level. |
+| [`source_role`](#provider-places-inherited_place-source_role){: #provider-places-inherited_place-source_role .spark-required} | `atom` |  | The PlaceRef role to read on the reached instance (terminal deref, not a via: hop). |
+| [`via`](#provider-places-inherited_place-via){: #provider-places-inherited_place-via } | `list(any)` |  | Hop chain to the instance holding the ref (unified #213 grammar). Bare atom = {:reverse, assignment: alias}; tuples are {:forward\|:reverse, assignment: alias} or {:forward\|:reverse, relationship: type\|[type:, alias:]}. Defaults to [role]. |
+| [`collapse`](#provider-places-inherited_place-collapse){: #provider-places-inherited_place-collapse } | `:first \| :last` |  | Collapses the result list (refs at source_role across reached instances) to that end; the calc then returns a single place or nil. |
 
 
 

--- a/documentation/how_to/use_diffo_place_geo.livemd
+++ b/documentation/how_to/use_diffo_place_geo.livemd
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.6.0"}
+    {:diffo, "~> 0.8.0"}
   ],
   config: [
     diffo: [ash_domains: [Diffo.Provider]]

--- a/documentation/how_to/use_diffo_provider_extension.livemd
+++ b/documentation/how_to/use_diffo_provider_extension.livemd
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.6.0"}
+    {:diffo, "~> 0.8.0"}
   ],
   config: [
     diffo: [ash_domains: [Diffo.Provider]]
@@ -522,50 +522,60 @@ The identity constraint `[:target_id, :alias]` on `AssignmentRelationship` guara
 most one assignment per (cluster, alias) pair — the `:primary_gpu` slot can only hold one
 assignment at a time.
 
-### Inheriting a place from an assigned resource
+### Inheriting a place or party across the graph
 
-A service or resource can declare that it inherits a place from the instance that assigned
-something to it — without creating its own `PlaceRef` edge. The `inherited_place` DSL entity
-in `places do` generates an Ash calculation that traverses the assignment graph at read time.
+A service or resource can inherit a place (or party) from an instance reached across the
+graph — without creating its own `PlaceRef` / `PartyRef` edge. `inherited_place` /
+`inherited_party` (in `places do` / `parties do`) generate an Ash calculation that **walks
+the instance graph** along a `via:` hop chain and reads a ref at `source_role` on the reached
+instance. `via:` is the **same grammar as `inherited_characteristic`** (`:forward`/`:reverse`
+× `assignment`/`relationship`), and both support `collapse`.
 
-In our Compute example: if a `GPU` instance has a `:data_centre` place, and a `Cluster`
-wants to surface the data centre of its primary GPU, it can declare:
+In our Compute example, a `Cluster` surfaces the data centre of its primary GPU:
 
 ```elixir
 provider do
   places do
-    # Traverses AssignmentRelationship where alias = :primary_gpu,
-    # reads PlaceRef with role :data_centre from the source GPU instance.
+    # bare-atom shorthand = {:reverse, assignment: :primary_gpu};
+    # reads the :data_centre PlaceRef on the reached GPU.
     inherited_place :primary_data_centre, via: [:primary_gpu], source_role: :data_centre
   end
 end
 ```
-
-Load it like any other calculation:
 
 ```elixir
 cluster = Ash.load!(cluster_1, [:primary_data_centre], domain: Compute)
 # cluster.primary_data_centre => [%DataCentre{...}]
 ```
 
-`inherited_party` works identically for party inheritance:
+`inherited_party` works identically, and either can take a forward / relationship hop and
+collapse to a single ref:
 
 ```elixir
-# Cluster inherits the operating Tenant from the GPU it was assigned from
 provider do
   parties do
     inherited_party :operator, via: [:primary_gpu], source_role: :operator
+
+    # forward relationship hop + collapse to one owner
+    inherited_party :rack_owner,
+      via: [{:forward, relationship: [alias: :rack]}],
+      source_role: :owner,
+      collapse: :first
   end
 end
 ```
+
+`via:` reaches the *instance* holding the ref; `source_role` is a fixed terminal deref —
+routing *through* a place or party (the ref graph) is a calculation concern, not a `via:`
+hop (see #227).
 
 ### Inheriting a characteristic across the graph
 
 `inherited_characteristic` (declared in `characteristics do`) derives a typed characteristic
 by *walking the graph* and surfaces it as an ordinary characteristic — no record is stored
-on the consuming instance. Where `inherited_place` / `inherited_party` only climb assignment
-inward, `inherited_characteristic` takes a `via:` chain of hops that can run in **either
-direction** over **assignment or relationship** edges.
+on the consuming instance. It shares the `via:` grammar with `inherited_place` /
+`inherited_party` — a chain of hops that can run in **either direction** over **assignment
+or relationship** edges — and here surfaces a typed characteristic rather than a place/party.
 
 Each hop is `{:forward | :reverse, assignment: alias}` or
 `{:forward | :reverse, relationship: type | [type: t, alias: a]}` — `:forward` follows the
@@ -624,9 +634,10 @@ calculate :primary_gpu_name, {:array, :string},
    [via: [:primary_gpu], field: :name]}
 ```
 
-**`FieldViaRelationship`** — traverses `DefinedSimpleRelationship` in the forward
-direction (source → target) filtered by `alias:` and/or `type:`. Use it when this
-instance is the *source* of a named forward relationship.
+**`FieldViaRelationship`** — traverses relationship edges (both `DefinedSimpleRelationship`
+and the general `Relationship`) in the forward direction (source → target) filtered by
+`alias:` and/or `type:`. Use it when this instance is the *source* of a named forward
+relationship.
 
 ```elixir
 # Name of the downstream node this GPU provides to
@@ -640,7 +651,7 @@ calculate :downstream_name, {:array, :string},
 | Value on the assignment record (`:value`, `:pool`) | `FieldFromAssignment` |
 | Field from the instance that assigned to me | `FieldViaAssignedRelationship` |
 | Field from an instance I have a forward relationship to | `FieldViaRelationship` |
-| Place/party inherited via assignment | `inherited_place` / `inherited_party` |
+| Place/party inherited across the graph | `inherited_place` / `inherited_party` (`via:` hops) |
 | Typed characteristic inherited across the graph | `inherited_characteristic` (`via:` hops) |
 
 ## Party Extension

--- a/documentation/how_to/use_diffo_provider_versioning.livemd
+++ b/documentation/how_to/use_diffo_provider_versioning.livemd
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.6.0"}
+    {:diffo, "~> 0.8.0"}
   ],
   config: [
     diffo: [ash_domains: [Diffo.Provider]]

--- a/documentation/how_to/use_diffo_type.livemd
+++ b/documentation/how_to/use_diffo_type.livemd
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.6.0"}
+    {:diffo, "~> 0.8.0"}
   ],
   consolidate_protocols: false
 )

--- a/lib/diffo/provider/components/calculations/inherited_party.ex
+++ b/lib/diffo/provider/components/calculations/inherited_party.ex
@@ -6,85 +6,85 @@ defmodule Diffo.Provider.Calculations.InheritedParty do
   @moduledoc """
   Backing calculation for `inherited_party` DSL declarations.
 
-  Traverses `AssignmentRelationship` by alias to reach source instances, then reads
-  their `PartyRef` records for the declared `source_role`. Injected automatically by
-  `TransformInheritedRefs` — do not reference this module directly; use the
+  Walks the instance graph along the `via:` hop chain (the shared
+  `Diffo.Provider.Calculations.Traversal` — `:forward`/`:reverse` over `assignment` /
+  `relationship` edges), then reads each reached instance's `PartyRef` records at the
+  declared `source_role`, optionally collapsing the result to one end. Injected
+  automatically by `TransformInheritedRefs` — do not reference this module directly; use the
   `inherited_party` DSL entity instead.
+
+  `via:` reaches the *instance* that holds the ref; the `source_role` deref is a fixed
+  terminal step, **not** a `via:` hop. Routing *through* a party — the ref graph — is a
+  calculation concern, not a `via:` capability (see #227).
 
   See `Diffo.Provider.Extension.InheritedPartyDeclaration` for the DSL options.
 
   ## Result shape
 
-  A list per input record. Each entry corresponds to one source instance reached
-  by the traversal:
-
-  - One or more `Diffo.Provider.Party` values when the source has matching
-    `PartyRef` records at `source_role`.
-  - `%Diffo.Unknown{}` when the source is reached but carries no `PartyRef`
-    at `source_role`.
-
-  When no sources are reached at all (e.g. no assignment), the result is `[]`.
-  Unknown is reserved for "we got here but the role isn't declared" — the
-  X-state from the AGENTS.md `Diffo.Unknown` discipline.
+  Without `collapse`, a list per input record — one or more `Diffo.Provider.Party` values
+  per reached instance that carries a `PartyRef` at `source_role`, or `%Diffo.Unknown{}`
+  when an instance is reached but has no `PartyRef` there. With `collapse: :first | :last`,
+  a single value (or `nil`). When no instance is reached at all, `[]` (or `nil` when
+  collapsing).
 
   ## Reason vocabulary
 
-  Only one reason is possible here — `PartyRef` is a universal indirection so
-  no cross-world dispatch is needed (which is why this calc is cleaner than the
-  characteristic equivalents):
+  `PartyRef` is a universal indirection (no cross-world dispatch), so only one reason:
 
-  - `:role_not_declared` — source instance reached but its `PartyRef` records
-    carry no entry at `source_role`. `:context` is `%{source_id: id, role: source_role}`.
+  - `:role_not_declared` — instance reached but its `PartyRef` records carry no entry at
+    `source_role`. `:context` is `%{source_id: id, role: source_role}`.
 
   ## `:world` stamping
 
-  `TransformInheritedRefs` passes the consumer's resource as `:world` at compile
-  time. Each emitted `%Diffo.Unknown{}` stamps it.
+  `TransformInheritedRefs` passes the consumer's resource as `:world` at compile time; each
+  emitted `%Diffo.Unknown{}` stamps it.
   """
   use Ash.Resource.Calculation
+
+  alias Diffo.Provider.Calculations.Traversal
 
   @impl true
   def load(_query, _opts, _context), do: []
 
   @impl true
   def calculate(records, opts, _context) do
-    via = opts[:via]
+    hops = opts[:hops]
     source_role = opts[:source_role]
     world = opts[:world]
+    collapse = opts[:collapse]
 
     Enum.map(records, fn record ->
-      final_ids =
-        Enum.reduce(via, [record.id], fn alias_step, ids ->
-          Enum.flat_map(ids, fn id ->
-            Diffo.Provider.AssignmentRelationship
-            |> Ash.Query.filter_input(target_id: id, alias: alias_step)
-            |> Ash.read!(domain: Diffo.Provider)
-            |> Enum.map(& &1.source_id)
-          end)
-        end)
-
-      Enum.flat_map(final_ids, fn id ->
-        parties =
-          Diffo.Provider.PartyRef
-          |> Ash.Query.filter_input(instance_id: id, role: source_role)
-          |> Ash.Query.load(:party)
-          |> Ash.read!(domain: Diffo.Provider)
-          |> Enum.map(& &1.party)
-
-        case parties do
-          [] ->
-            [
-              %Diffo.Unknown{
-                world: world,
-                reason: :role_not_declared,
-                context: %{source_id: id, role: source_role}
-              }
-            ]
-
-          _ ->
-            parties
-        end
-      end)
+      record.id
+      |> Traversal.walk(hops)
+      |> Enum.flat_map(&resolve_parties(&1, source_role, world))
+      |> collapse(collapse)
     end)
   end
+
+  defp resolve_parties(id, source_role, world) do
+    parties =
+      Diffo.Provider.PartyRef
+      |> Ash.Query.filter_input(instance_id: id, role: source_role)
+      |> Ash.Query.load(:party)
+      |> Ash.read!(domain: Diffo.Provider)
+      |> Enum.map(& &1.party)
+
+    case parties do
+      [] ->
+        [
+          %Diffo.Unknown{
+            world: world,
+            reason: :role_not_declared,
+            context: %{source_id: id, role: source_role}
+          }
+        ]
+
+      _ ->
+        parties
+    end
+  end
+
+  defp collapse(entries, nil), do: entries
+  defp collapse(entries, :first), do: List.first(entries)
+  defp collapse(entries, :last), do: List.last(entries)
 end

--- a/lib/diffo/provider/components/calculations/inherited_place.ex
+++ b/lib/diffo/provider/components/calculations/inherited_place.ex
@@ -6,85 +6,85 @@ defmodule Diffo.Provider.Calculations.InheritedPlace do
   @moduledoc """
   Backing calculation for `inherited_place` DSL declarations.
 
-  Traverses `AssignmentRelationship` by alias to reach source instances, then reads
-  their `PlaceRef` records for the declared `source_role`. Injected automatically by
-  `TransformInheritedRefs` — do not reference this module directly; use the
+  Walks the instance graph along the `via:` hop chain (the shared
+  `Diffo.Provider.Calculations.Traversal` — `:forward`/`:reverse` over `assignment` /
+  `relationship` edges), then reads each reached instance's `PlaceRef` records at the
+  declared `source_role`, optionally collapsing the result to one end. Injected
+  automatically by `TransformInheritedRefs` — do not reference this module directly; use the
   `inherited_place` DSL entity instead.
+
+  `via:` reaches the *instance* that holds the ref; the `source_role` deref is a fixed
+  terminal step, **not** a `via:` hop. Routing *through* a place — the ref graph — is a
+  calculation concern, not a `via:` capability (see #227).
 
   See `Diffo.Provider.Extension.InheritedPlaceDeclaration` for the DSL options.
 
   ## Result shape
 
-  A list per input record. Each entry corresponds to one source instance reached
-  by the traversal:
-
-  - One or more `Diffo.Provider.Place` values when the source has matching
-    `PlaceRef` records at `source_role`.
-  - `%Diffo.Unknown{}` when the source is reached but carries no `PlaceRef`
-    at `source_role`.
-
-  When no sources are reached at all (e.g. no assignment), the result is `[]`.
-  Unknown is reserved for "we got here but the role isn't declared" — the
-  X-state from the AGENTS.md `Diffo.Unknown` discipline.
+  Without `collapse`, a list per input record — one or more `Diffo.Provider.Place` values
+  per reached instance that carries a `PlaceRef` at `source_role`, or `%Diffo.Unknown{}`
+  when an instance is reached but has no `PlaceRef` there. With `collapse: :first | :last`,
+  a single value (or `nil`). When no instance is reached at all, `[]` (or `nil` when
+  collapsing).
 
   ## Reason vocabulary
 
-  Only one reason is possible here — `PlaceRef` is a universal indirection so
-  no cross-world dispatch is needed (which is why this calc is cleaner than the
-  characteristic equivalents):
+  `PlaceRef` is a universal indirection (no cross-world dispatch), so only one reason:
 
-  - `:role_not_declared` — source instance reached but its `PlaceRef` records
-    carry no entry at `source_role`. `:context` is `%{source_id: id, role: source_role}`.
+  - `:role_not_declared` — instance reached but its `PlaceRef` records carry no entry at
+    `source_role`. `:context` is `%{source_id: id, role: source_role}`.
 
   ## `:world` stamping
 
-  `TransformInheritedRefs` passes the consumer's resource as `:world` at compile
-  time. Each emitted `%Diffo.Unknown{}` stamps it.
+  `TransformInheritedRefs` passes the consumer's resource as `:world` at compile time; each
+  emitted `%Diffo.Unknown{}` stamps it.
   """
   use Ash.Resource.Calculation
+
+  alias Diffo.Provider.Calculations.Traversal
 
   @impl true
   def load(_query, _opts, _context), do: []
 
   @impl true
   def calculate(records, opts, _context) do
-    via = opts[:via]
+    hops = opts[:hops]
     source_role = opts[:source_role]
     world = opts[:world]
+    collapse = opts[:collapse]
 
     Enum.map(records, fn record ->
-      final_ids =
-        Enum.reduce(via, [record.id], fn alias_step, ids ->
-          Enum.flat_map(ids, fn id ->
-            Diffo.Provider.AssignmentRelationship
-            |> Ash.Query.filter_input(target_id: id, alias: alias_step)
-            |> Ash.read!(domain: Diffo.Provider)
-            |> Enum.map(& &1.source_id)
-          end)
-        end)
-
-      Enum.flat_map(final_ids, fn id ->
-        places =
-          Diffo.Provider.PlaceRef
-          |> Ash.Query.filter_input(instance_id: id, role: source_role)
-          |> Ash.Query.load(:place)
-          |> Ash.read!(domain: Diffo.Provider)
-          |> Enum.map(& &1.place)
-
-        case places do
-          [] ->
-            [
-              %Diffo.Unknown{
-                world: world,
-                reason: :role_not_declared,
-                context: %{source_id: id, role: source_role}
-              }
-            ]
-
-          _ ->
-            places
-        end
-      end)
+      record.id
+      |> Traversal.walk(hops)
+      |> Enum.flat_map(&resolve_places(&1, source_role, world))
+      |> collapse(collapse)
     end)
   end
+
+  defp resolve_places(id, source_role, world) do
+    places =
+      Diffo.Provider.PlaceRef
+      |> Ash.Query.filter_input(instance_id: id, role: source_role)
+      |> Ash.Query.load(:place)
+      |> Ash.read!(domain: Diffo.Provider)
+      |> Enum.map(& &1.place)
+
+    case places do
+      [] ->
+        [
+          %Diffo.Unknown{
+            world: world,
+            reason: :role_not_declared,
+            context: %{source_id: id, role: source_role}
+          }
+        ]
+
+      _ ->
+        places
+    end
+  end
+
+  defp collapse(entries, nil), do: entries
+  defp collapse(entries, :first), do: List.first(entries)
+  defp collapse(entries, :last), do: List.last(entries)
 end

--- a/lib/diffo/provider/extension.ex
+++ b/lib/diffo/provider/extension.ex
@@ -342,24 +342,30 @@ defmodule Diffo.Provider.Extension do
   @inherited_party_entity %Spark.Dsl.Entity{
     name: :inherited_party,
     describe:
-      "Declares a party derived by traversing the assignment graph — generates a calculation, no PartyRef node created",
+      "Declares a party derived by walking the instance graph along a via: hop chain then reading a PartyRef at source_role — generates a calculation, no PartyRef node created",
     target: InheritedPartyDeclaration,
     args: [:role],
     schema: [
       role: [
         type: :atom,
-        doc: "The role name — also the default alias to follow on AssignmentRelationship.",
+        doc: "The generated calc name and surfaced PartyRef role; default single hop alias.",
         required: true
       ],
       via: [
-        type: {:list, :atom},
+        type: {:list, :any},
         doc:
-          "Sequence of assignment aliases to traverse. Defaults to [role] for single-hop. Use a list for multi-level."
+          "Hop chain to the instance holding the ref (unified #213 grammar). Bare atom = {:reverse, assignment: alias}; tuples are {:forward|:reverse, assignment: alias} or {:forward|:reverse, relationship: type|[type:, alias:]}. Defaults to [role]."
       ],
       source_role: [
         type: :atom,
-        doc: "The PartyRef role to pick up on the arrived-at instance.",
+        doc:
+          "The PartyRef role to read on the reached instance (terminal deref, not a via: hop).",
         required: true
+      ],
+      collapse: [
+        type: {:one_of, [:first, :last]},
+        doc:
+          "Collapses the result list (refs at source_role across reached instances) to that end; the calc then returns a single party or nil."
       ]
     ]
   }
@@ -450,24 +456,30 @@ defmodule Diffo.Provider.Extension do
   @inherited_place_entity %Spark.Dsl.Entity{
     name: :inherited_place,
     describe:
-      "Declares a place derived by traversing the assignment graph — generates a calculation, no PlaceRef node created",
+      "Declares a place derived by walking the instance graph along a via: hop chain then reading a PlaceRef at source_role — generates a calculation, no PlaceRef node created",
     target: InheritedPlaceDeclaration,
     args: [:role],
     schema: [
       role: [
         type: :atom,
-        doc: "The role name — also the default alias to follow on AssignmentRelationship.",
+        doc: "The generated calc name and surfaced PlaceRef role; default single hop alias.",
         required: true
       ],
       via: [
-        type: {:list, :atom},
+        type: {:list, :any},
         doc:
-          "Sequence of assignment aliases to traverse. Defaults to [role] for single-hop. Use a list for multi-level."
+          "Hop chain to the instance holding the ref (unified #213 grammar). Bare atom = {:reverse, assignment: alias}; tuples are {:forward|:reverse, assignment: alias} or {:forward|:reverse, relationship: type|[type:, alias:]}. Defaults to [role]."
       ],
       source_role: [
         type: :atom,
-        doc: "The PlaceRef role to pick up on the arrived-at instance.",
+        doc:
+          "The PlaceRef role to read on the reached instance (terminal deref, not a via: hop).",
         required: true
+      ],
+      collapse: [
+        type: {:one_of, [:first, :last]},
+        doc:
+          "Collapses the result list (refs at source_role across reached instances) to that end; the calc then returns a single place or nil."
       ]
     ]
   }

--- a/lib/diffo/provider/extension/inherited_party_declaration.ex
+++ b/lib/diffo/provider/extension/inherited_party_declaration.ex
@@ -6,30 +6,41 @@ defmodule Diffo.Provider.Extension.InheritedPartyDeclaration do
   @moduledoc """
   DSL entity for an `inherited_party` declaration inside `parties do` on an Instance resource.
 
-  Generates an Ash calculation of the same name as `role` that traverses the assignment
-  graph to inherit a party from a related source instance. The calculation is injected
-  by `TransformInheritedRefs` at compile time — no `PartyRef` edge is created on the
-  consuming instance itself.
+  Generates an Ash calculation of the same name as `role` that walks the instance graph to
+  inherit a party from a reached instance. The calculation is injected by
+  `TransformInheritedRefs` at compile time — no `PartyRef` edge is created on the consuming
+  instance itself.
 
   ## Fields
 
-  - `role` — atom; the name of the generated calculation (and the party slot name from
-    the consumer's perspective).
-  - `source_role` — atom; the `PartyRef` role to read from the resolved source instance
-    (e.g. `:provider`). Required.
-  - `via` — optional list of alias atoms for multi-hop traversal. When nil the role name
-    is used as the single alias step (single-hop default). When provided, each step
-    filters `AssignmentRelationship` by that alias atom before following `source_id` to
-    the next set of instances.
+  - `role` — atom; the name of the generated calculation (and the party slot name from the
+    consumer's perspective — the surfaced `PartyRef` carries this role).
+  - `source_role` — atom; the `PartyRef` role to read on each reached instance
+    (e.g. `:provider`). Required. This terminal deref is **not** a `via:` hop — `via:`
+    reaches the instance; routing *through* a party (the ref graph) is calc territory
+    (see #227).
+  - `via` — the hop chain to the instance holding the ref, in the unified #213 grammar
+    (shared with `inherited_characteristic`): a bare atom is `{:reverse, assignment: alias}`
+    shorthand; tuples are `{:forward | :reverse, assignment: alias}` or
+    `{:forward | :reverse, relationship: type | [type: t, alias: a]}`. When `nil`, defaults
+    to `[role]`. See `Diffo.Provider.Extension.Traversal`.
+  - `collapse` — `:first` or `:last`; collapses the consumer-ordered result list (the refs
+    at `source_role` across reached instances) to that end. When set, the calc returns a
+    single party or `nil` rather than a list.
 
   ## Example
 
       parties do
         inherited_party :provider, source_role: :provider
         inherited_party :nni_owner, via: [:uplink], source_role: :owner
+        # forward relationship hop + collapse to a single owner
+        inherited_party :circuit_owner,
+          via: [{:forward, relationship: [alias: :circuit]}],
+          source_role: :owner,
+          collapse: :first
       end
   """
-  defstruct [:role, :via, :source_role, __spark_metadata__: nil]
+  defstruct [:role, :via, :source_role, :collapse, __spark_metadata__: nil]
 
   defimpl String.Chars do
     def to_string(struct), do: inspect(struct)

--- a/lib/diffo/provider/extension/inherited_place_declaration.ex
+++ b/lib/diffo/provider/extension/inherited_place_declaration.ex
@@ -6,30 +6,41 @@ defmodule Diffo.Provider.Extension.InheritedPlaceDeclaration do
   @moduledoc """
   DSL entity for an `inherited_place` declaration inside `places do` on an Instance resource.
 
-  Generates an Ash calculation of the same name as `role` that traverses the assignment
-  graph to inherit a place from a related source instance. The calculation is injected
-  by `TransformInheritedRefs` at compile time — no `PlaceRef` edge is created on the
-  consuming instance itself.
+  Generates an Ash calculation of the same name as `role` that walks the instance graph to
+  inherit a place from a reached instance. The calculation is injected by
+  `TransformInheritedRefs` at compile time — no `PlaceRef` edge is created on the consuming
+  instance itself.
 
   ## Fields
 
-  - `role` — atom; the name of the generated calculation (and the place slot name from
-    the consumer's perspective).
-  - `source_role` — atom; the `PlaceRef` role to read from the resolved source instance
-    (e.g. `:location`). Required.
-  - `via` — optional list of alias atoms for multi-hop traversal. When nil the role name
-    is used as the single alias step (single-hop default). When provided, each step
-    filters `AssignmentRelationship` by that alias atom before following `source_id` to
-    the next set of instances.
+  - `role` — atom; the name of the generated calculation (and the place slot name from the
+    consumer's perspective — the surfaced `PlaceRef` carries this role).
+  - `source_role` — atom; the `PlaceRef` role to read on each reached instance
+    (e.g. `:location`). Required. This terminal deref is **not** a `via:` hop — `via:`
+    reaches the instance; routing *through* a place (the ref graph) is calc territory
+    (see #227).
+  - `via` — the hop chain to the instance holding the ref, in the unified #213 grammar
+    (shared with `inherited_characteristic`): a bare atom is `{:reverse, assignment: alias}`
+    shorthand; tuples are `{:forward | :reverse, assignment: alias}` or
+    `{:forward | :reverse, relationship: type | [type: t, alias: a]}`. When `nil`, defaults
+    to `[role]`. See `Diffo.Provider.Extension.Traversal`.
+  - `collapse` — `:first` or `:last`; collapses the consumer-ordered result list (the refs
+    at `source_role` across reached instances) to that end. When set, the calc returns a
+    single place or `nil` rather than a list.
 
   ## Example
 
       places do
         inherited_place :installation_site, source_role: :location
         inherited_place :exchange, via: [:primary, :uplink], source_role: :location
+        # forward relationship hop + collapse to the single reached place
+        inherited_place :poi,
+          via: [{:forward, relationship: [alias: :circuit]}, {:reverse, assignment: :cvlan}],
+          source_role: :locates,
+          collapse: :first
       end
   """
-  defstruct [:role, :via, :source_role, __spark_metadata__: nil]
+  defstruct [:role, :via, :source_role, :collapse, __spark_metadata__: nil]
 
   defimpl String.Chars do
     def to_string(struct), do: inspect(struct)

--- a/lib/diffo/provider/extension/transformers/transform_inherited_refs.ex
+++ b/lib/diffo/provider/extension/transformers/transform_inherited_refs.ex
@@ -47,41 +47,55 @@ defmodule Diffo.Provider.Extension.Transformers.TransformInheritedRefs do
   end
 
   defp inject_place_calculation(dsl_state, %InheritedPlaceDeclaration{} = decl, resource) do
-    via = decl.via || [decl.role]
+    case Traversal.normalize(decl.via, decl.role) do
+      {:ok, hops} ->
+        type = if decl.collapse, do: :map, else: {:array, :map}
 
-    calc = %Ash.Resource.Calculation{
-      name: decl.role,
-      type: {:array, :map},
-      calculation:
-        {Diffo.Provider.Calculations.InheritedPlace,
-         [via: via, source_role: decl.source_role, world: resource]},
-      description: "Inherited place via assignment alias traversal",
-      arguments: [],
-      public?: true,
-      allow_nil?: true,
-      constraints: []
-    }
+        calc = %Ash.Resource.Calculation{
+          name: decl.role,
+          type: type,
+          calculation:
+            {Diffo.Provider.Calculations.InheritedPlace,
+             [hops: hops, source_role: decl.source_role, world: resource, collapse: decl.collapse]},
+          description: "Inherited place via instance-graph traversal",
+          arguments: [],
+          public?: true,
+          allow_nil?: true,
+          constraints: []
+        }
 
-    Transformer.add_entity(dsl_state, [:calculations], calc)
+        Transformer.add_entity(dsl_state, [:calculations], calc)
+
+      # Malformed via — leave it for VerifyPlaces to report as a clean DslError.
+      {:error, _reason} ->
+        dsl_state
+    end
   end
 
   defp inject_party_calculation(dsl_state, %InheritedPartyDeclaration{} = decl, resource) do
-    via = decl.via || [decl.role]
+    case Traversal.normalize(decl.via, decl.role) do
+      {:ok, hops} ->
+        type = if decl.collapse, do: :map, else: {:array, :map}
 
-    calc = %Ash.Resource.Calculation{
-      name: decl.role,
-      type: {:array, :map},
-      calculation:
-        {Diffo.Provider.Calculations.InheritedParty,
-         [via: via, source_role: decl.source_role, world: resource]},
-      description: "Inherited party via assignment alias traversal",
-      arguments: [],
-      public?: true,
-      allow_nil?: true,
-      constraints: []
-    }
+        calc = %Ash.Resource.Calculation{
+          name: decl.role,
+          type: type,
+          calculation:
+            {Diffo.Provider.Calculations.InheritedParty,
+             [hops: hops, source_role: decl.source_role, world: resource, collapse: decl.collapse]},
+          description: "Inherited party via instance-graph traversal",
+          arguments: [],
+          public?: true,
+          allow_nil?: true,
+          constraints: []
+        }
 
-    Transformer.add_entity(dsl_state, [:calculations], calc)
+        Transformer.add_entity(dsl_state, [:calculations], calc)
+
+      # Malformed via — leave it for VerifyParties to report as a clean DslError.
+      {:error, _reason} ->
+        dsl_state
+    end
   end
 
   defp inject_inherited_characteristic_calculation(

--- a/lib/diffo/provider/extension/verifiers/verify_parties.ex
+++ b/lib/diffo/provider/extension/verifiers/verify_parties.ex
@@ -9,6 +9,8 @@ defmodule Diffo.Provider.Extension.Verifiers.VerifyParties do
   alias Spark.Dsl.Verifier
   alias Spark.Error.DslError
   alias Diffo.Provider.Extension.Info
+  alias Diffo.Provider.Extension.InheritedPartyDeclaration
+  alias Diffo.Provider.Extension.Traversal
 
   @impl true
   def verify(dsl_state) do
@@ -60,9 +62,32 @@ defmodule Diffo.Provider.Extension.Verifiers.VerifyParties do
         end
       end)
 
-    case duplicate_errors ++ type_errors do
+    via_errors = via_errors(parties, resource)
+
+    case duplicate_errors ++ type_errors ++ via_errors do
       [] -> :ok
       errors -> {:error, errors}
     end
+  end
+
+  defp via_errors(parties, resource) do
+    parties
+    |> Enum.filter(&is_struct(&1, InheritedPartyDeclaration))
+    |> Enum.reduce([], fn decl, acc ->
+      case Traversal.normalize(decl.via, decl.role) do
+        {:ok, _hops} ->
+          acc
+
+        {:error, reason} ->
+          [
+            DslError.exception(
+              module: resource,
+              path: [:provider, :parties, decl.role],
+              message: "inherited_party #{inspect(decl.role)}: invalid via — #{inspect(reason)}"
+            )
+            | acc
+          ]
+      end
+    end)
   end
 end

--- a/lib/diffo/provider/extension/verifiers/verify_places.ex
+++ b/lib/diffo/provider/extension/verifiers/verify_places.ex
@@ -9,6 +9,8 @@ defmodule Diffo.Provider.Extension.Verifiers.VerifyPlaces do
   alias Spark.Dsl.Verifier
   alias Spark.Error.DslError
   alias Diffo.Provider.Extension.Info
+  alias Diffo.Provider.Extension.InheritedPlaceDeclaration
+  alias Diffo.Provider.Extension.Traversal
 
   @impl true
   def verify(dsl_state) do
@@ -60,9 +62,32 @@ defmodule Diffo.Provider.Extension.Verifiers.VerifyPlaces do
         end
       end)
 
-    case duplicate_errors ++ type_errors do
+    via_errors = via_errors(places, resource)
+
+    case duplicate_errors ++ type_errors ++ via_errors do
       [] -> :ok
       errors -> {:error, errors}
     end
+  end
+
+  defp via_errors(places, resource) do
+    places
+    |> Enum.filter(&is_struct(&1, InheritedPlaceDeclaration))
+    |> Enum.reduce([], fn decl, acc ->
+      case Traversal.normalize(decl.via, decl.role) do
+        {:ok, _hops} ->
+          acc
+
+        {:error, reason} ->
+          [
+            DslError.exception(
+              module: resource,
+              path: [:provider, :places, decl.role],
+              message: "inherited_place #{inspect(decl.role)}: invalid via — #{inspect(reason)}"
+            )
+            | acc
+          ]
+      end
+    end)
   end
 end

--- a/test/provider/extension/inherited_place_party_traversal_test.exs
+++ b/test/provider/extension/inherited_place_party_traversal_test.exs
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025 diffo contributors <https://github.com/diffo-dev/diffo/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Diffo.Provider.Extension.InheritedPlacePartyTraversalTest do
+  @moduledoc """
+  #226 — `inherited_place` / `inherited_party` adopt the unified #213 `via:` grammar
+  (forward relationship hops) plus `collapse`, over the shared `Traversal.walk`. `via:`
+  reaches the instance; `source_role` is the terminal `PlaceRef` / `PartyRef` deref.
+  """
+  use ExUnit.Case, async: true
+  @moduletag :domain_extended
+
+  alias Diffo.Test.Servo
+
+  setup do
+    AshNeo4j.Sandbox.checkout()
+    on_exit(&AshNeo4j.Sandbox.rollback/0)
+  end
+
+  describe "inherited_place via a forward relationship hop (#226)" do
+    test "reaches each contained card and reads its :location PlaceRef" do
+      probe = probe!()
+      c1 = card!("card-1")
+      c2 = card!("card-2")
+      contains!(probe, c1)
+      contains!(probe, c2)
+      p1 = place_on!(c1, :location, "LOC-1", "Loc 1")
+      p2 = place_on!(c2, :location, "LOC-2", "Loc 2")
+
+      probe = Ash.load!(probe, [:contained_locations], domain: Servo)
+
+      assert probe.contained_locations |> Enum.map(& &1.id) |> Enum.sort() ==
+               Enum.sort([p1.id, p2.id])
+    end
+
+    test "collapse :first / :last pick an end of the reached places" do
+      probe = probe!()
+      c1 = card!("card-1")
+      c2 = card!("card-2")
+      contains!(probe, c1)
+      contains!(probe, c2)
+      p1 = place_on!(c1, :location, "LOC-1", "Loc 1")
+      p2 = place_on!(c2, :location, "LOC-2", "Loc 2")
+
+      probe = Ash.load!(probe, [:first_location, :last_location], domain: Servo)
+
+      refute is_list(probe.first_location)
+      assert probe.first_location.id == p1.id
+      assert probe.last_location.id == p2.id
+    end
+
+    test "collapse returns nil when nothing is reached" do
+      probe = probe!() |> Ash.load!([:first_location], domain: Servo)
+      assert probe.first_location == nil
+    end
+  end
+
+  describe "inherited_party via a forward relationship hop (#226)" do
+    test "reaches each contained card and reads its :provider PartyRef" do
+      probe = probe!()
+      c1 = card!("card-1")
+      c2 = card!("card-2")
+      contains!(probe, c1)
+      contains!(probe, c2)
+      a = party_on!(c1, :provider, "ORG-1", "Org 1")
+      b = party_on!(c2, :provider, "ORG-2", "Org 2")
+
+      probe = Ash.load!(probe, [:contained_providers], domain: Servo)
+
+      assert probe.contained_providers |> Enum.map(& &1.id) |> Enum.sort() ==
+               Enum.sort([a.id, b.id])
+    end
+
+    test "collapse :first picks one provider in reached order" do
+      probe = probe!()
+      c1 = card!("card-1")
+      c2 = card!("card-2")
+      contains!(probe, c1)
+      contains!(probe, c2)
+      a = party_on!(c1, :provider, "ORG-1", "Org 1")
+      _b = party_on!(c2, :provider, "ORG-2", "Org 2")
+
+      probe = Ash.load!(probe, [:first_provider], domain: Servo)
+
+      refute is_list(probe.first_provider)
+      assert probe.first_provider.id == a.id
+    end
+  end
+
+  defp probe!(name \\ "probe") do
+    {:ok, probe} = Servo.build_traversal_probe(%{name: name})
+    probe
+  end
+
+  defp card!(name) do
+    {:ok, card} = Servo.build_card(%{name: name})
+    card
+  end
+
+  defp contains!(source, target) do
+    Diffo.Provider.create_defined_simple_relationship!(%{
+      type: :contains,
+      source_id: source.id,
+      target_id: target.id
+    })
+  end
+
+  defp place_on!(instance, role, id, name) do
+    place = Diffo.Provider.create_place!(:GeographicSite, %{id: id, name: name})
+    Diffo.Provider.create_place_ref!(%{instance_id: instance.id, role: role, place_id: place.id})
+    place
+  end
+
+  defp party_on!(instance, role, id, name) do
+    party = Diffo.Provider.create_party!(:Organization, %{id: id, name: name})
+    Diffo.Provider.create_party_ref!(%{instance_id: instance.id, role: role, party_id: party.id})
+    party
+  end
+end

--- a/test/support/resource/instance/traversal_probe.ex
+++ b/test/support/resource/instance/traversal_probe.ex
@@ -83,6 +83,35 @@ defmodule Diffo.Test.Instance.TraversalProbe do
         read: :card
     end
 
+    # #226 — inherited_place / inherited_party adopt the same via: grammar (forward
+    # relationship hop) + collapse; source_role is the terminal deref on the reached card.
+    places do
+      inherited_place :contained_locations,
+        via: [{:forward, relationship: :contains}],
+        source_role: :location
+
+      inherited_place :first_location,
+        via: [{:forward, relationship: :contains}],
+        source_role: :location,
+        collapse: :first
+
+      inherited_place :last_location,
+        via: [{:forward, relationship: :contains}],
+        source_role: :location,
+        collapse: :last
+    end
+
+    parties do
+      inherited_party :contained_providers,
+        via: [{:forward, relationship: :contains}],
+        source_role: :provider
+
+      inherited_party :first_provider,
+        via: [{:forward, relationship: :contains}],
+        source_role: :provider,
+        collapse: :first
+    end
+
     behaviour do
       actions do
         create :build

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -741,41 +741,79 @@ Servo.assign_port(cvc, %{
 ## `inherited_place` and `inherited_party` DSL
 
 Declare `inherited_place` or `inherited_party` inside `places do` / `parties do` on an
-Instance resource to generate an Ash calculation that traverses the assignment graph and
-inherits a place or party from the source instance.
+Instance resource to generate an Ash calculation that **walks the instance graph** to a
+reached instance and reads its `PlaceRef` / `PartyRef` at `source_role`.
 
-No `PlaceRef` or `PartyRef` edge is created on the consuming instance — the calculation
-IS the reference. The result is a list (consistent with all traversal calculations).
+No `PlaceRef` or `PartyRef` edge is created on the consuming instance — the calculation IS
+the reference. The result is a list, or (with `collapse`) a single value or `nil`.
+
+Since the #226 alignment, `via:` uses the **same hop grammar as `inherited_characteristic`**
+(`:forward`/`:reverse` × `assignment`/`relationship`, over the shared `Traversal.walk`), and
+both gain `collapse: :first | :last`.
 
 ```elixir
 provider do
   places do
-    # Single-hop: traverses AssignmentRelationship where alias = :installation_site,
-    # reads PlaceRef with role :location from the source instance
+    # bare-atom shorthand = {:reverse, assignment: :installation_site}
     inherited_place :installation_site, source_role: :location
 
-    # Explicit alias (same as above written long-form)
-    inherited_place :exchange, via: [:exchange], source_role: :location
-
-    # Multi-hop: :primary slot on this instance → :uplink slot on that instance →
-    # reads :location PlaceRef from the final source
+    # multi-hop, all reverse-assignment (each bare atom)
     inherited_place :exchange, via: [:primary, :uplink], source_role: :location
+
+    # forward relationship hop + collapse to the single reached place
+    inherited_place :poi,
+      via: [{:forward, relationship: [alias: :circuit]}, {:reverse, assignment: :cvlan}],
+      source_role: :locates,
+      collapse: :first
   end
 
   parties do
     inherited_party :provider, source_role: :provider
+
+    inherited_party :circuit_owner,
+      via: [{:forward, relationship: [alias: :circuit]}],
+      source_role: :owner,
+      collapse: :first
   end
 end
 ```
 
 Options:
-- `source_role:` *(required)* — the `PlaceRef`/`PartyRef` role to read from the resolved
-  source instance.
-- `via:` *(optional)* — explicit list of alias atoms for multi-hop traversal. When
-  omitted, the role name itself is used as the single alias step.
+- `source_role:` *(required)* — the `PlaceRef`/`PartyRef` role to read on the reached
+  instance.
+- `via:` *(optional)* — the hop chain (unified #213 grammar; see the
+  `inherited_characteristic` DSL section). A bare atom is `{:reverse, assignment: alias}`;
+  tuples are `{:forward | :reverse, assignment: alias}` or
+  `{:forward | :reverse, relationship: type | [type: t, alias: a]}`. Defaults to `[role]`.
+- `collapse:` *(optional)* — `:first` or `:last`; collapses the consumer-ordered result
+  (refs at `source_role` across reached instances) to that end. The calc then returns a
+  single value or `nil` instead of a list — e.g. picking one of several maintainers.
 
-The DSL entity must be declared in the correct section (`places do` for `inherited_place`,
-`parties do` for `inherited_party`). The generated calculation name matches the declared role.
+The DSL entity must be in the correct section (`places do` / `parties do`); the generated
+calc name matches `role`, and that role is also the role the surfaced `PlaceRef`/`PartyRef`
+carries.
+
+### What `via:` reaches (and what it doesn't)
+
+`via:` traverses the **instance graph** — instance↔instance via assignment/relationship
+edges — to the instance that *holds* the ref. The `source_role` deref (instance → its
+place/party) is a **fixed terminal step, not a `via:` hop**: a `Place`/`Party` is a
+different node kind reached over a `PlaceRef`/`PartyRef` edge, which the grammar doesn't
+traverse. So you **cannot** chain `via:` *through* a place or party — e.g. instance → place →
+keyholder party, or place → place (LOC↔LOP, CSA↔POI) — that ref-graph routing is a
+calculation concern, tracked in #227. Workaround today: also attach such a place/party to an
+instance, so a `via:` traversal that reaches that instance can inherit it.
+
+### Migration from the alias-list `via:`
+
+Backward compatible — existing declarations are unchanged:
+
+| before | after |
+|---|---|
+| `inherited_place :x, source_role: :y` | unchanged |
+| `inherited_place :x, via: [:a, :b], source_role: :y` | unchanged (each bare atom = reverse assignment) |
+| *(not expressible)* | `inherited_place :x, via: [{:forward, relationship: :contains}], source_role: :y` |
+| *(not expressible)* | `inherited_party :x, via: […], source_role: :y, collapse: :first` |
 
 ### JSON surfacing
 


### PR DESCRIPTION
Fixes #226. inherited_place/inherited_party adopt the unified #213 via: grammar plus collapse, over Traversal.walk; source_role stays the terminal deref. Verifiers validate via:. Migration guide + livebook accuracy fixes + dep pins to 0.8.0. Spine traversal deferred to #227; address-location facet to #229.