### PR TITLE
docs: make v0.9.0 consumer-solid (Neo4j 2026.05, require_atomic, installer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ type prefix (`fix:`, `feat:`, `deps:`, `chore:`, `refactor:`, `test:`, `docs:`).
 
 To cut a release from `dev`:
 
+0. **Pre-flight, before bumping anything:** `mix test` green, `mix format --check-formatted`
+   clean, **`mix docs` emits zero warnings**, and the consumer-facing docs are current —
+   `{:diffo, "~> X.Y"}` pins in `README.md` and every livebook match the version being cut,
+   the livebook `Mix.install` setup still works, and any new consumer requirement (e.g. a
+   needed `config :ash, …`) is documented in the README, the installer, and the changelog.
+   These are exactly the things that surface late (at `mix hex.publish`) if skipped.
 1. `mix git_ops.release --dry-run` — preview the computed version and changelog without
    writing anything. The bump follows semver from the commit types since the last `v*` tag
    (`fix:` → patch, `feat:` → minor).
@@ -346,6 +352,14 @@ mix docs                              # spark.cheat_sheets + ex_doc + spark.repl
 - **`mix docs`** output lands in `doc/`, which is **gitignored** — generated HTML and the
   livebooks copied there are not tracked. The source livebooks live in `documentation/how_to/`
   and the root `diffo.livemd`; edit those, not `doc/`.
+- **`mix docs` must emit zero warnings — treat them as build failures.** ExDoc warns when a
+  `@spec` or doc references a type that is undefined or private (e.g. a phantom
+  `Ash.Resource.record()` — Ash has no such type; use `struct()` or a real local `@type`).
+  These warnings compile fine and accumulate silently, then dump *en masse* at
+  `mix hex.publish` — the worst place to discover them. Run `mix docs` (or
+  `mix docs --warnings-as-errors`) and clear **every** warning as part of any change that
+  touches public `@spec`s/`@doc`s, and again before a release. Do not suppress with
+  `skip_*` config — fix the reference.
 
 ## Module naming and Neo4j labels
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -724,3 +724,11 @@ not. Add any useful hypotheses as a follow-up comment on the issue, then leave i
   typically has many forward `DefinedSimpleRelationship` records pointing to unrelated things.
   Without at least one filter the result is a noisy mix. Always supply `alias:`, `type:`, or
   both.
+- Adding `require_atomic? true` to an update action — atomic-by-default is **off** domain-wide
+  (`config :ash, :require_atomic_by_default?, false` in `config/config.exs`) because nearly
+  every action manages relationships (`manage_relationship` → `before_action` hooks) or runs
+  `present`/state-machine validations, none of which are atomic. Even genuinely pure-attribute
+  actions can't go atomic yet: ash_neo4j's renderer can't express the `update_timestamp`
+  (`now()`/`is_distinct_from`) or constrained-`increment` atomics Ash generates (ash_neo4j#396,
+  blocking #240). Consumers (and the livebooks/`mix diffo.install`) must set the same config —
+  diffo's resources recompile under the consumer's config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
   non-atomic validations), and `Diffo.Type.Dynamic` gains `dump_to_embedded/2` +
   `cast_from_embedded/2` for ash 3.28's composite embedded casting (#239). Tracks `ash` 3.29.
 
+  > **Upgrading from 0.8.x:** consumers must add `config :ash, :require_atomic_by_default?, false`
+  > to their own config — diffo's resources recompile under the consumer's config, and without
+  > it the edge-managing actions raise `must be performed atomically`. `mix diffo.install` and
+  > the livebooks now set this for you. Target Neo4j is now **2026.05** (Cypher 25 / BOLT 6.0).
+
 ## [v0.8.0](https://github.com/diffo-dev/diffo/compare/v0.7.0...v0.8.0) (2026-06-03)
 
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,25 @@ Alternatively, add `diffo` to your list of dependencies in `mix.exs` manually:
 ```elixir
 def deps do
   [
-    {:diffo, "~> 0.8.0"}
+    {:diffo, "~> 0.9.0"}
   ]
 end
 ```
 
-You will need [Neo4j](https://github.com/neo4j/neo4j) available. We recommend the Neo4j Community 5 latest, available at [Neo4j Deploymnent Centre](https://neo4j.com/deployment-center/) which can be installed locally. You can also configure connection to a cloud based database service such as [Neo4j AuraDB](https://neo4j.com/product/auradb/).
+If you add `diffo` manually (rather than via the installer above), also disable Ash's
+atomic-by-default updates — diffo is an edge-managing graph domain, so almost every action
+manages relationships or runs non-atomic validations and cannot be rendered atomically:
+
+```elixir
+# config/config.exs
+config :ash, :require_atomic_by_default?, false
+```
+
+You will need [Neo4j](https://github.com/neo4j/neo4j) available. Diffo targets **Neo4j 2026.05**
+— Cypher 25 over BOLT 6.0, via `ash_neo4j` 0.10 — available at the
+[Neo4j Deployment Center](https://neo4j.com/deployment-center/) and installable locally. You
+can also configure a connection to a cloud database service such as
+[Neo4j AuraDB](https://neo4j.com/product/auradb/).
 
 ## Tutorial
 

--- a/diffo.livemd
+++ b/diffo.livemd
@@ -9,7 +9,10 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.8.0"}
+    {:diffo, "~> 0.9.0"}
+  ],
+  config: [
+    ash: [require_atomic_by_default?: false]
   ],
   consolidate_protocols: false
 )
@@ -39,7 +42,7 @@ Diffo uses the [Ash Neo4j DataLayer](https://github.com/diffo-dev/ash_neo4j), wh
 
 While [Neo4j community edition](https://github.com/neo4j/neo4j) is open source and you can build from source it is likely that you'll use an installation.
 
-[AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running. You can install latest major Neo4j versions from the community tab at [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb), or use the [5.26.8 direct link](https://neo4j.com/download-thanks/?edition=community&release=5.26.8&flavour=rpm)
+[AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running. Diffo targets **Neo4j 2026.05** — Cypher 25 over BOLT 6.0 (via `ash_neo4j` 0.10). Install it from the community tab at the [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb).
 
 When you install neo4j you'll typically have a default username and password. Take note of this and any other non-standard config.
 

--- a/documentation/how_to/use_diffo_place_geo.livemd
+++ b/documentation/how_to/use_diffo_place_geo.livemd
@@ -9,10 +9,11 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.8.0"}
+    {:diffo, "~> 0.9.0"}
   ],
   config: [
-    diffo: [ash_domains: [Diffo.Provider]]
+    diffo: [ash_domains: [Diffo.Provider]],
+    ash: [require_atomic_by_default?: false]
   ],
   consolidate_protocols: false
 )
@@ -47,9 +48,9 @@ the TMF675 `geoJson` shape.
 ### Installing Neo4j and Configuring Bolty
 
 `GeographicLocation` persists through the [Ash Neo4j DataLayer](https://github.com/diffo-dev/ash_neo4j),
-which requires Neo4j to be installed and running. You can install latest major Neo4j
-versions from the community tab at [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb),
-or use the [5.26.8 direct link](https://neo4j.com/download-thanks/?edition=community&release=5.26.8&flavour=rpm).
+which requires Neo4j to be installed and running. Diffo targets **Neo4j 2026.05** — Cypher 25
+over BOLT 6.0 (via `ash_neo4j` 0.10). Install it from the community tab at the
+[Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb).
 
 Update the configuration below as necessary and evaluate.
 

--- a/documentation/how_to/use_diffo_provider_extension.livemd
+++ b/documentation/how_to/use_diffo_provider_extension.livemd
@@ -9,10 +9,11 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.8.0"}
+    {:diffo, "~> 0.9.0"}
   ],
   config: [
-    diffo: [ash_domains: [Diffo.Provider]]
+    diffo: [ash_domains: [Diffo.Provider]],
+    ash: [require_atomic_by_default?: false]
   ],
   consolidate_protocols: false
 )
@@ -43,7 +44,7 @@ Diffo uses the [Ash Neo4j DataLayer](https://github.com/diffo-dev/ash_neo4j), wh
 
 While [Neo4j community edition](https://github.com/neo4j/neo4j) is open source and you can build from source it is likely that you'll use an installation.
 
-[AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running. You can install latest major Neo4j versions from the community tab at [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb), or use the [5.26.8 direct link](https://neo4j.com/download-thanks/?edition=community&release=5.26.8&flavour=rpm)
+[AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running. Diffo targets **Neo4j 2026.05** — Cypher 25 over BOLT 6.0 (via `ash_neo4j` 0.10). Install it from the community tab at the [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb).
 
 When you install neo4j you'll typically have a default username and password. Take note of this and any other non-standard config.
 

--- a/documentation/how_to/use_diffo_provider_versioning.livemd
+++ b/documentation/how_to/use_diffo_provider_versioning.livemd
@@ -9,10 +9,11 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.8.0"}
+    {:diffo, "~> 0.9.0"}
   ],
   config: [
-    diffo: [ash_domains: [Diffo.Provider]]
+    diffo: [ash_domains: [Diffo.Provider]],
+    ash: [require_atomic_by_default?: false]
   ],
   consolidate_protocols: false
 )
@@ -46,9 +47,8 @@ Diffo uses the [Ash Neo4j DataLayer](https://github.com/diffo-dev/ash_neo4j), wh
 Neo4j to be installed and running.
 
 [AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j).
-You can install latest major Neo4j versions from the community tab at
-[Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb), or use the
-[5.26.8 direct link](https://neo4j.com/download-thanks/?edition=community&release=5.26.8&flavour=rpm)
+Diffo targets **Neo4j 2026.05** — Cypher 25 over BOLT 6.0 (via `ash_neo4j` 0.10). Install it
+from the community tab at the [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb).
 
 Update the configuration below as necessary and evaluate.
 

--- a/documentation/how_to/use_diffo_type.livemd
+++ b/documentation/how_to/use_diffo_type.livemd
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:diffo, "~> 0.8.0"}
+    {:diffo, "~> 0.9.0"}
   ],
   consolidate_protocols: false
 )

--- a/lib/diffo/provider.ex
+++ b/lib/diffo/provider.ex
@@ -35,6 +35,10 @@ defmodule Diffo.Provider do
     # hand-written dispatcher function on `Diffo.Provider` that dispatches on the
     # record's own resource.
     resource Diffo.Provider.Instance
+    # The generic Resource leaf (`BaseInstance` + `Resource`), counterpart to the
+    # generic Service `Diffo.Provider.Instance`. `create_instance!/1` dispatches a
+    # `:resourceSpecification` here; reads still go through the abstract reader.
+    resource Diffo.Provider.ResourceInstance
 
     resource Diffo.Provider.Relationship do
       define :create_relationship, action: :create
@@ -236,6 +240,45 @@ defmodule Diffo.Provider do
   # on the record's own resource — the lifecycle actions live on the `Service`
   # fragment, so any service leaf carries them.
   # ============================================================================
+
+  @doc """
+  Creates a generic Service or Resource instance, dispatching on the referenced
+  specification's type.
+
+  Reads the specification named by `:specified_by`: a `:serviceSpecification`
+  creates a `Diffo.Provider.Instance` (the generic Service), a
+  `:resourceSpecification` creates a `Diffo.Provider.ResourceInstance` (the generic
+  Resource). This is the provider-only entry point — consumer instance kinds declare
+  their own `:build` action and are created through their own domain, not here.
+
+  Symmetric with `create_place!/2` and `create_party!/2`; dispatch is on the spec
+  type rather than a passed atom, since the spec already names the kind.
+  """
+  @spec create_instance!(map()) :: Ash.Resource.record()
+  def create_instance!(attrs) when is_map(attrs) do
+    {leaf, type} =
+      attrs |> Map.fetch!(:specified_by) |> get_specification_by_id!() |> instance_leaf_for()
+
+    Ash.create!(leaf, Map.put(attrs, :type, type), action: :create, domain: __MODULE__)
+  end
+
+  @doc "Same as `create_instance!/1` but returns `{:ok, record}` or `{:error, error}`."
+  @spec create_instance(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  def create_instance(attrs) when is_map(attrs) do
+    case get_specification_by_id(Map.get(attrs, :specified_by)) do
+      {:ok, spec} ->
+        {leaf, type} = instance_leaf_for(spec)
+        Ash.create(leaf, Map.put(attrs, :type, type), action: :create, domain: __MODULE__)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp instance_leaf_for(%{type: :serviceSpecification}), do: {Diffo.Provider.Instance, :service}
+
+  defp instance_leaf_for(%{type: :resourceSpecification}),
+    do: {Diffo.Provider.ResourceInstance, :resource}
 
   @doc """
   Loads an instance by id and projects it to its concrete Service/Resource leaf.

--- a/lib/diffo/provider.ex
+++ b/lib/diffo/provider.ex
@@ -13,6 +13,41 @@ defmodule Diffo.Provider do
     description "Extensible Ash Resources and API related to Providing TMF Services and Resources"
   end
 
+  @typedoc """
+  A record produced by an Instance creator (`create_instance!/1`, `create_instance/1`) —
+  the generic Service or Resource leaf the dispatcher constructs.
+  """
+  @type instance_record :: %Diffo.Provider.Instance{} | %Diffo.Provider.ResourceInstance{}
+
+  @typedoc """
+  A record produced by a Place creator (`create_place!/2`, `create_place/2`) — one of the
+  blessed TMF place leaves the dispatcher constructs (`:PlaceRef` yields the abstract
+  `Provider.Place`).
+  """
+  @type place_record ::
+          %Diffo.Provider.Place{}
+          | %Diffo.Provider.GeographicAddress{}
+          | %Diffo.Provider.GeographicSite{}
+          | %Diffo.Provider.GeographicLocation{}
+
+  @typedoc """
+  A record produced by a Party creator (`create_party!/2`, `create_party/2`) — one of the
+  blessed TMF party leaves the dispatcher constructs (`:PartyRef`/`:Entity` yield the
+  abstract `Provider.Party`).
+  """
+  @type party_record ::
+          %Diffo.Provider.Party{}
+          | %Diffo.Provider.Organization{}
+          | %Diffo.Provider.Individual{}
+
+  @typedoc """
+  An open-world resource record. Reads project to the outermost concrete world via
+  `AshNeo4j.worlds/1` — which may be a consumer-domain leaf unknown at compile time —
+  and update/delete dispatch on whatever record they are handed. The set is therefore
+  genuinely unbounded: a deliberate `struct()`, not a missing type.
+  """
+  @type projected_record :: struct()
+
   resources do
     resource Diffo.Provider.Specification do
       define :create_specification, action: :create
@@ -254,7 +289,7 @@ defmodule Diffo.Provider do
   Symmetric with `create_place!/2` and `create_party!/2`; dispatch is on the spec
   type rather than a passed atom, since the spec already names the kind.
   """
-  @spec create_instance!(map()) :: Ash.Resource.record()
+  @spec create_instance!(map()) :: instance_record()
   def create_instance!(attrs) when is_map(attrs) do
     {leaf, type} =
       attrs |> Map.fetch!(:specified_by) |> get_specification_by_id!() |> instance_leaf_for()
@@ -263,7 +298,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `create_instance!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec create_instance(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec create_instance(map()) :: {:ok, instance_record()} | {:error, term()}
   def create_instance(attrs) when is_map(attrs) do
     case get_specification_by_id(Map.get(attrs, :specified_by)) do
       {:ok, spec} ->
@@ -285,7 +320,7 @@ defmodule Diffo.Provider do
 
   Accepts a `:load` opt applied to the projected leaf (e.g. `load: [:event]`).
   """
-  @spec get_instance_by_id!(String.t(), keyword()) :: Ash.Resource.record()
+  @spec get_instance_by_id!(String.t(), keyword()) :: projected_record()
   def get_instance_by_id!(id, opts \\ []) when is_binary(id) do
     Diffo.Provider.Instance
     |> Ash.get!(id, domain: __MODULE__)
@@ -295,7 +330,7 @@ defmodule Diffo.Provider do
 
   @doc "Same as `get_instance_by_id!/2` but returns `{:ok, record}` or `{:error, error}`."
   @spec get_instance_by_id(String.t(), keyword()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+          {:ok, projected_record()} | {:error, term()}
   def get_instance_by_id(id, opts \\ []) when is_binary(id) do
     case Ash.get(Diffo.Provider.Instance, id, domain: __MODULE__) do
       {:ok, abstract} -> {:ok, abstract |> project_instance() |> load_projection(opts)}
@@ -311,7 +346,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists all instances, each projected to its concrete Service/Resource leaf."
-  @spec list_instances!() :: [Ash.Resource.record()]
+  @spec list_instances!() :: [projected_record()]
   def list_instances! do
     Diffo.Provider.Instance
     |> Ash.read!(action: :list, domain: __MODULE__)
@@ -319,7 +354,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds instances whose name contains the query, each projected to its concrete leaf."
-  @spec find_instances_by_name!(String.t()) :: [Ash.Resource.record()]
+  @spec find_instances_by_name!(String.t()) :: [projected_record()]
   def find_instances_by_name!(query) do
     Diffo.Provider.Instance
     |> Ash.Query.for_read(:find_by_name, %{query: query})
@@ -328,7 +363,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds instances by specification id, each projected to its concrete leaf."
-  @spec find_instances_by_specification_id!(String.t()) :: [Ash.Resource.record()]
+  @spec find_instances_by_specification_id!(String.t()) :: [projected_record()]
   def find_instances_by_specification_id!(query) do
     Diffo.Provider.Instance
     |> Ash.Query.for_read(:find_by_specification_id, %{query: query})
@@ -492,7 +527,7 @@ defmodule Diffo.Provider do
   Raises `ArgumentError` for unknown types — consumer-specific shapes go
   through consumer domains.
   """
-  @spec create_place!(place_type(), map()) :: Ash.Resource.record()
+  @spec create_place!(place_type(), map()) :: place_record()
   def create_place!(:PlaceRef, attrs) when is_map(attrs) do
     Ash.create!(Diffo.Provider.Place, attrs, action: :create, domain: __MODULE__)
   end
@@ -513,7 +548,7 @@ defmodule Diffo.Provider do
   Same as `create_place!/2` but returns `{:ok, record}` or `{:error, error}`.
   """
   @spec create_place(place_type(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+          {:ok, place_record()} | {:error, term()}
   def create_place(:PlaceRef, attrs) when is_map(attrs) do
     Ash.create(Diffo.Provider.Place, attrs, action: :create, domain: __MODULE__)
   end
@@ -535,7 +570,7 @@ defmodule Diffo.Provider do
   their `:define` action; the abstract `Provider.Place` updates via its
   inherited `:update` action.
   """
-  @spec update_place!(Ash.Resource.record(), map()) :: Ash.Resource.record()
+  @spec update_place!(projected_record(), map()) :: projected_record()
   def update_place!(%Diffo.Provider.GeographicAddress{} = record, attrs),
     do: Ash.update!(record, attrs, action: :define, domain: __MODULE__)
 
@@ -549,8 +584,8 @@ defmodule Diffo.Provider do
     do: Ash.update!(record, attrs, action: :update, domain: __MODULE__)
 
   @doc "Same as `update_place!/2` but returns `{:ok, record}` or `{:error, error}`."
-  @spec update_place(Ash.Resource.record(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec update_place(projected_record(), map()) ::
+          {:ok, projected_record()} | {:error, term()}
   def update_place(%Diffo.Provider.GeographicAddress{} = record, attrs),
     do: Ash.update(record, attrs, action: :define, domain: __MODULE__)
 
@@ -566,7 +601,7 @@ defmodule Diffo.Provider do
   @doc """
   Deletes a Place record (any subtype, dispatched on its struct module).
   """
-  @spec delete_place!(Ash.Resource.record()) :: :ok
+  @spec delete_place!(projected_record()) :: :ok
   def delete_place!(record) when is_struct(record) do
     Ash.destroy!(record, domain: __MODULE__)
     :ok
@@ -578,7 +613,7 @@ defmodule Diffo.Provider do
   Accepts either a single record or a list of records (returns
   `%Ash.BulkResult{}` for lists).
   """
-  @spec delete_place(Ash.Resource.record() | [Ash.Resource.record()]) ::
+  @spec delete_place(projected_record() | [projected_record()]) ::
           :ok | {:error, term()} | Ash.BulkResult.t()
   def delete_place(record) when is_struct(record) do
     Ash.destroy(record, domain: __MODULE__)
@@ -595,7 +630,7 @@ defmodule Diffo.Provider do
   `MyApp.SydneyExchange`, etc.) or the abstract `Provider.Place` if no
   concrete world resolves.
   """
-  @spec get_place_by_id!(String.t()) :: Ash.Resource.record()
+  @spec get_place_by_id!(String.t()) :: projected_record()
   def get_place_by_id!(id) when is_binary(id) do
     Diffo.Provider.Place
     |> Ash.get!(id, domain: __MODULE__)
@@ -603,7 +638,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `get_place_by_id!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec get_place_by_id(String.t()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec get_place_by_id(String.t()) :: {:ok, projected_record()} | {:error, term()}
   def get_place_by_id(id) when is_binary(id) do
     case Ash.get(Diffo.Provider.Place, id, domain: __MODULE__) do
       {:ok, abstract} -> {:ok, project_place(abstract)}
@@ -614,7 +649,7 @@ defmodule Diffo.Provider do
   @doc """
   Lists all Places, each projected to its outermost concrete world.
   """
-  @spec list_places!() :: [Ash.Resource.record()]
+  @spec list_places!() :: [projected_record()]
   def list_places! do
     Diffo.Provider.Place
     |> Ash.read!(action: :list, domain: __MODULE__)
@@ -622,7 +657,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `list_places!/0` but returns `{:ok, list}` or `{:error, error}`."
-  @spec list_places() :: {:ok, [Ash.Resource.record()]} | {:error, term()}
+  @spec list_places() :: {:ok, [projected_record()]} | {:error, term()}
   def list_places do
     case Ash.read(Diffo.Provider.Place, action: :list, domain: __MODULE__) do
       {:ok, places} -> {:ok, Enum.map(places, &project_place/1)}
@@ -633,7 +668,7 @@ defmodule Diffo.Provider do
   @doc """
   Finds Places whose id contains the query, each projected to its concrete world.
   """
-  @spec find_places_by_id!(String.t()) :: [Ash.Resource.record()]
+  @spec find_places_by_id!(String.t()) :: [projected_record()]
   def find_places_by_id!(query) do
     Diffo.Provider.Place
     |> Ash.Query.for_read(:find_by_id, %{query: query})
@@ -644,7 +679,7 @@ defmodule Diffo.Provider do
   @doc """
   Finds Places whose name contains the query, each projected to its concrete world.
   """
-  @spec find_places_by_name!(String.t()) :: [Ash.Resource.record()]
+  @spec find_places_by_name!(String.t()) :: [projected_record()]
   def find_places_by_name!(query) do
     Diffo.Provider.Place
     |> Ash.Query.for_read(:find_by_name, %{query: query})
@@ -696,7 +731,7 @@ defmodule Diffo.Provider do
   Raises `ArgumentError` for unknown types — consumer-specific shapes go
   through consumer domains.
   """
-  @spec create_party!(party_type(), map()) :: Ash.Resource.record()
+  @spec create_party!(party_type(), map()) :: party_record()
   def create_party!(:PartyRef, attrs) when is_map(attrs) do
     Ash.create!(Diffo.Provider.Party, attrs, action: :create, domain: __MODULE__)
   end
@@ -724,7 +759,7 @@ defmodule Diffo.Provider do
 
   @doc "Same as `create_party!/2` but returns `{:ok, record}` or `{:error, error}`."
   @spec create_party(party_type(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+          {:ok, party_record()} | {:error, term()}
   def create_party(:PartyRef, attrs) when is_map(attrs) do
     Ash.create(Diffo.Provider.Party, attrs, action: :create, domain: __MODULE__)
   end
@@ -755,7 +790,7 @@ defmodule Diffo.Provider do
   `:define` action; the abstract `Provider.Party` updates via its inherited
   `:update` action.
   """
-  @spec update_party!(Ash.Resource.record(), map()) :: Ash.Resource.record()
+  @spec update_party!(projected_record(), map()) :: projected_record()
   def update_party!(%Diffo.Provider.Organization{} = record, attrs),
     do: Ash.update!(record, attrs, action: :define, domain: __MODULE__)
 
@@ -766,8 +801,8 @@ defmodule Diffo.Provider do
     do: Ash.update!(record, attrs, action: :update, domain: __MODULE__)
 
   @doc "Same as `update_party!/2` but returns `{:ok, record}` or `{:error, error}`."
-  @spec update_party(Ash.Resource.record(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec update_party(projected_record(), map()) ::
+          {:ok, projected_record()} | {:error, term()}
   def update_party(%Diffo.Provider.Organization{} = record, attrs),
     do: Ash.update(record, attrs, action: :define, domain: __MODULE__)
 
@@ -778,7 +813,7 @@ defmodule Diffo.Provider do
     do: Ash.update(record, attrs, action: :update, domain: __MODULE__)
 
   @doc "Deletes a Party record (any subtype, dispatched on its struct module)."
-  @spec delete_party!(Ash.Resource.record()) :: :ok
+  @spec delete_party!(projected_record()) :: :ok
   def delete_party!(record) when is_struct(record) do
     Ash.destroy!(record, domain: __MODULE__)
     :ok
@@ -790,7 +825,7 @@ defmodule Diffo.Provider do
   Accepts either a single record or a list of records (returns
   `%Ash.BulkResult{}` for lists).
   """
-  @spec delete_party(Ash.Resource.record() | [Ash.Resource.record()]) ::
+  @spec delete_party(projected_record() | [projected_record()]) ::
           :ok | {:error, term()} | Ash.BulkResult.t()
   def delete_party(record) when is_struct(record) do
     Ash.destroy(record, domain: __MODULE__)
@@ -807,7 +842,7 @@ defmodule Diffo.Provider do
   `Provider.Individual`, `MyApp.Carrier`, etc.) or the abstract
   `Provider.Party` if no concrete world resolves.
   """
-  @spec get_party_by_id!(String.t()) :: Ash.Resource.record()
+  @spec get_party_by_id!(String.t()) :: projected_record()
   def get_party_by_id!(id) when is_binary(id) do
     Diffo.Provider.Party
     |> Ash.get!(id, domain: __MODULE__)
@@ -815,7 +850,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `get_party_by_id!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec get_party_by_id(String.t()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec get_party_by_id(String.t()) :: {:ok, projected_record()} | {:error, term()}
   def get_party_by_id(id) when is_binary(id) do
     case Ash.get(Diffo.Provider.Party, id, domain: __MODULE__) do
       {:ok, abstract} -> {:ok, project_party(abstract)}
@@ -824,7 +859,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists all Parties, each projected to its outermost concrete world."
-  @spec list_parties!() :: [Ash.Resource.record()]
+  @spec list_parties!() :: [projected_record()]
   def list_parties! do
     Diffo.Provider.Party
     |> Ash.read!(action: :list, domain: __MODULE__)
@@ -832,7 +867,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `list_parties!/0` but returns `{:ok, list}` or `{:error, error}`."
-  @spec list_parties() :: {:ok, [Ash.Resource.record()]} | {:error, term()}
+  @spec list_parties() :: {:ok, [projected_record()]} | {:error, term()}
   def list_parties do
     case Ash.read(Diffo.Provider.Party, action: :list, domain: __MODULE__) do
       {:ok, parties} -> {:ok, Enum.map(parties, &project_party/1)}
@@ -841,7 +876,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds Parties whose id contains the query, each projected to its concrete world."
-  @spec find_parties_by_id!(String.t()) :: [Ash.Resource.record()]
+  @spec find_parties_by_id!(String.t()) :: [projected_record()]
   def find_parties_by_id!(query) do
     Diffo.Provider.Party
     |> Ash.Query.for_read(:find_by_id, %{query: query})
@@ -850,7 +885,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds Parties whose name contains the query, each projected to its concrete world."
-  @spec find_parties_by_name!(String.t()) :: [Ash.Resource.record()]
+  @spec find_parties_by_name!(String.t()) :: [projected_record()]
   def find_parties_by_name!(query) do
     Diffo.Provider.Party
     |> Ash.Query.for_read(:find_by_name, %{query: query})
@@ -898,7 +933,7 @@ defmodule Diffo.Provider do
       target: "LOC-001"
       target: some_place_struct
   """
-  @spec create_place_ref!(map()) :: Ash.Resource.record()
+  @spec create_place_ref!(map()) :: %Diffo.Provider.PlaceRef{}
   def create_place_ref!(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -909,7 +944,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `create_place_ref!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec create_place_ref(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec create_place_ref(map()) :: {:ok, %Diffo.Provider.PlaceRef{}} | {:error, term()}
   def create_place_ref(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -922,8 +957,8 @@ defmodule Diffo.Provider do
   @doc """
   Lists PlaceRefs whose source matches the given Instance/Party/Place.
   """
-  @spec list_place_refs_from(tagged_source() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_place_refs_from(tagged_source() | projected_record()) ::
+          [%Diffo.Provider.PlaceRef{}]
   def list_place_refs_from({:instance, id}),
     do: list_place_refs_by_instance_id!(id)
 
@@ -940,8 +975,8 @@ defmodule Diffo.Provider do
   @doc """
   Lists PlaceRefs targeting the given Place.
   """
-  @spec list_place_refs_targeting(String.t() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_place_refs_targeting(String.t() | projected_record()) ::
+          [%Diffo.Provider.PlaceRef{}]
   def list_place_refs_targeting(target) do
     list_place_refs_by_place_id!(normalize_target_id(target))
   end
@@ -958,7 +993,7 @@ defmodule Diffo.Provider do
       source: some_place_struct
       source: some_party_struct
   """
-  @spec create_party_ref!(map()) :: Ash.Resource.record()
+  @spec create_party_ref!(map()) :: %Diffo.Provider.PartyRef{}
   def create_party_ref!(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -969,7 +1004,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `create_party_ref!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec create_party_ref(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec create_party_ref(map()) :: {:ok, %Diffo.Provider.PartyRef{}} | {:error, term()}
   def create_party_ref(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -980,8 +1015,8 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists PartyRefs whose source matches the given Instance/Place/Party."
-  @spec list_party_refs_from(tagged_source() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_party_refs_from(tagged_source() | projected_record()) ::
+          [%Diffo.Provider.PartyRef{}]
   def list_party_refs_from({:instance, id}),
     do: list_party_refs_by_instance_id!(id)
 
@@ -996,8 +1031,8 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists PartyRefs targeting the given Party."
-  @spec list_party_refs_targeting(String.t() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_party_refs_targeting(String.t() | projected_record()) ::
+          [%Diffo.Provider.PartyRef{}]
   def list_party_refs_targeting(target) do
     list_party_refs_by_party_id!(normalize_target_id(target))
   end

--- a/lib/diffo/provider/components/instance.ex
+++ b/lib/diffo/provider/components/instance.ex
@@ -14,8 +14,9 @@ defmodule Diffo.Provider.Instance do
   Service/Resource leaf) via `AshNeo4j.worlds/1` before returning.
 
   An instance is **exactly one** of Service or Resource. Concrete Resource
-  instances compose `[BaseInstance, Resource]` on their own leaf (e.g.
-  `Diffo.Test.Instance.ResourceInstance`); they carry no service lifecycle.
+  instances compose `[BaseInstance, Resource]` on their own leaf — the generic
+  `Diffo.Provider.ResourceInstance`, or a consumer leaf like `MyApp.Card`; they
+  carry no service lifecycle.
 
   See `Diffo.Provider.BaseInstance` for the shared base, `Diffo.Provider.Service`
   and `Diffo.Provider.Resource` for the subtype fragments.

--- a/lib/diffo/provider/components/resource_instance.ex
+++ b/lib/diffo/provider/components/resource_instance.ex
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 diffo contributors <https://github.com/diffo-dev/diffo/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Diffo.Provider.ResourceInstance do
+  @moduledoc """
+  The generic TMF Resource Instance — the resource-flavoured counterpart to
+  `Diffo.Provider.Instance` (the generic Service).
+
+  Composes `[BaseInstance, Resource]`, so it is a concrete Resource carrying the
+  resource lifecycle (`lifecycle_state` and the TMF639 status attributes), usable
+  directly. `Diffo.Provider.create_instance!/1` dispatches here when the referenced
+  specification is a `:resourceSpecification`.
+
+  An instance is **exactly one** of Service or Resource: this leaf carries the
+  resource lifecycle, not the service state machine. Reads still go through the
+  abstract reader `Diffo.Provider.Instance`, which projects each record to its
+  outermost concrete world via `AshNeo4j.worlds/1`.
+
+  See `Diffo.Provider.Resource` for the resource subtype fragment and
+  `Diffo.Provider.BaseInstance` for the shared base.
+  """
+  alias Diffo.Provider.BaseInstance
+  alias Diffo.Provider.Resource
+
+  use Ash.Resource,
+    fragments: [BaseInstance, Resource],
+    domain: Diffo.Provider
+
+  resource do
+    description "An Ash Resource for a TMF Resource Instance"
+    plural_name :resource_instances
+  end
+end

--- a/lib/mix/tasks/diffo.install.ex
+++ b/lib/mix/tasks/diffo.install.ex
@@ -32,7 +32,7 @@ if Code.ensure_loaded?(Igniter) do
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
         group: :ash,
-        installs: [{:ash_neo4j, "~> 0.5"}],
+        installs: [{:ash_neo4j, "~> 0.10"}],
         example: __MODULE__.Docs.example()
       }
     end
@@ -56,6 +56,16 @@ if Code.ensure_loaded?(Igniter) do
             quote(do: Diffo.Unwrap.AshCustomExpression)
           )
         end
+      )
+      # Diffo is an edge-managing graph domain — nearly every action manages
+      # relationships (before_action hooks) or runs non-atomic validations, so
+      # atomic-by-default updates (enforced once ash_neo4j 0.10 advertised atomic
+      # support) don't apply. Disable it so diffo's resources compile and run.
+      |> Igniter.Project.Config.configure(
+        "config.exs",
+        :ash,
+        [:require_atomic_by_default?],
+        false
       )
     end
   end

--- a/test/provider/instance_test.exs
+++ b/test/provider/instance_test.exs
@@ -245,6 +245,45 @@ defmodule Diffo.Provider.InstanceTest do
                )
     end
 
+    test "create_instance! dispatches a serviceSpecification to the generic Service" do
+      spec = Diffo.Provider.create_specification!(%{name: "broadband"})
+
+      instance = Diffo.Provider.create_instance!(%{name: "broadband_0001", specified_by: spec.id})
+
+      assert %Diffo.Provider.Instance{} = instance
+      assert instance.type == :service
+    end
+
+    test "create_instance! dispatches a resourceSpecification to the generic Resource" do
+      spec =
+        Diffo.Provider.create_specification!(%{
+          name: "copperPath",
+          type: :resourceSpecification,
+          description: "Copper Path Resource"
+        })
+
+      instance =
+        Diffo.Provider.create_instance!(%{name: "copperPath_0001", specified_by: spec.id})
+
+      assert %Diffo.Provider.ResourceInstance{} = instance
+      assert instance.type == :resource
+    end
+
+    test "create_instance/1 returns {:ok, instance} for a valid spec" do
+      spec = Diffo.Provider.create_specification!(%{name: "evcAccess"})
+
+      assert {:ok, %Diffo.Provider.Instance{type: :service}} =
+               Diffo.Provider.create_instance(%{name: "evcAccess_0001", specified_by: spec.id})
+    end
+
+    test "create_instance/1 returns {:error, _} when the specification is missing" do
+      assert {:error, _} =
+               Diffo.Provider.create_instance(%{
+                 name: "ghost",
+                 specified_by: "00000000-0000-0000-0000-000000000000"
+               })
+    end
+
     test "create instance with characteristics - success" do
       specification = Diffo.Provider.create_specification!(%{name: "evc"})
 


### PR DESCRIPTION
Makes v0.9.0 consumer-solid before publish — the doc/livebook/installer currency pass for the Neo4j 2026.05 + ash_neo4j 0.10.1 stack. Folds into the **v0.9.0** tag (still unpublished).

## Why
v0.9.0 introduces a **new consumer requirement** — `config :ash, :require_atomic_by_default?, false` — because diffo's edge-managing resources recompile under the consumer's config and otherwise raise `must be performed atomically`. That, plus stale version pins and old Neo4j guidance, meant the README/livebooks/installer were not solid for the release.

## Changes
- **Version pins** `~> 0.8.0` → `~> 0.9.0` (README + all 5 livebooks).
- **require_atomic config** added to the DB-touching livebooks' `Mix.install` and the README manual-install path; `mix diffo.install` now writes it too.
- **Installer** `{:ash_neo4j, "~> 0.5"}` → `~> 0.10` (was stale/broken for 0.9.0).
- **Neo4j guidance** retargeted to **2026.05 / Cypher 25 / BOLT 6.0**; dropped 5.26.8 refs. bolty 0.2.0 keeps the same config keys (no connection changes).
- **AGENTS.md** + **CHANGELOG** notes (require_atomic posture; 0.8.x upgrade note).

## Verification
- Full suite green: **905 passing**; `mix format --check-formatted` clean.
- The only code change is the igniter installer task; livebook/README are docs.

## Note
The livebook fix relies on `Mix.install`'s `config:` being applied before diffo compiles (standard behaviour) — worth one live livebook smoke-run before the demo.

After merge: move the `v0.9.0` tag to the new `main` HEAD, then `mix hex.publish` from `main`.
