### PR TITLE
fix: public Diffo.Provider.create_instance + ResourceInstance; precise dispatcher typespecs (#244)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ type prefix (`fix:`, `feat:`, `deps:`, `chore:`, `refactor:`, `test:`, `docs:`).
 
 To cut a release from `dev`:
 
+0. **Pre-flight, before bumping anything:** `mix test` green, `mix format --check-formatted`
+   clean, **`mix docs` emits zero warnings**, and the consumer-facing docs are current —
+   `{:diffo, "~> X.Y"}` pins in `README.md` and every livebook match the version being cut,
+   the livebook `Mix.install` setup still works, and any new consumer requirement (e.g. a
+   needed `config :ash, …`) is documented in the README, the installer, and the changelog.
+   These are exactly the things that surface late (at `mix hex.publish`) if skipped.
 1. `mix git_ops.release --dry-run` — preview the computed version and changelog without
    writing anything. The bump follows semver from the commit types since the last `v*` tag
    (`fix:` → patch, `feat:` → minor).
@@ -346,6 +352,14 @@ mix docs                              # spark.cheat_sheets + ex_doc + spark.repl
 - **`mix docs`** output lands in `doc/`, which is **gitignored** — generated HTML and the
   livebooks copied there are not tracked. The source livebooks live in `documentation/how_to/`
   and the root `diffo.livemd`; edit those, not `doc/`.
+- **`mix docs` must emit zero warnings — treat them as build failures.** ExDoc warns when a
+  `@spec` or doc references a type that is undefined or private (e.g. a phantom
+  `Ash.Resource.record()` — Ash has no such type; use `struct()` or a real local `@type`).
+  These warnings compile fine and accumulate silently, then dump *en masse* at
+  `mix hex.publish` — the worst place to discover them. Run `mix docs` (or
+  `mix docs --warnings-as-errors`) and clear **every** warning as part of any change that
+  touches public `@spec`s/`@doc`s, and again before a release. Do not suppress with
+  `skip_*` config — fix the reference.
 
 ## Module naming and Neo4j labels
 

--- a/lib/diffo/provider.ex
+++ b/lib/diffo/provider.ex
@@ -35,6 +35,10 @@ defmodule Diffo.Provider do
     # hand-written dispatcher function on `Diffo.Provider` that dispatches on the
     # record's own resource.
     resource Diffo.Provider.Instance
+    # The generic Resource leaf (`BaseInstance` + `Resource`), counterpart to the
+    # generic Service `Diffo.Provider.Instance`. `create_instance!/1` dispatches a
+    # `:resourceSpecification` here; reads still go through the abstract reader.
+    resource Diffo.Provider.ResourceInstance
 
     resource Diffo.Provider.Relationship do
       define :create_relationship, action: :create
@@ -236,6 +240,45 @@ defmodule Diffo.Provider do
   # on the record's own resource — the lifecycle actions live on the `Service`
   # fragment, so any service leaf carries them.
   # ============================================================================
+
+  @doc """
+  Creates a generic Service or Resource instance, dispatching on the referenced
+  specification's type.
+
+  Reads the specification named by `:specified_by`: a `:serviceSpecification`
+  creates a `Diffo.Provider.Instance` (the generic Service), a
+  `:resourceSpecification` creates a `Diffo.Provider.ResourceInstance` (the generic
+  Resource). This is the provider-only entry point — consumer instance kinds declare
+  their own `:build` action and are created through their own domain, not here.
+
+  Symmetric with `create_place!/2` and `create_party!/2`; dispatch is on the spec
+  type rather than a passed atom, since the spec already names the kind.
+  """
+  @spec create_instance!(map()) :: Ash.Resource.record()
+  def create_instance!(attrs) when is_map(attrs) do
+    {leaf, type} =
+      attrs |> Map.fetch!(:specified_by) |> get_specification_by_id!() |> instance_leaf_for()
+
+    Ash.create!(leaf, Map.put(attrs, :type, type), action: :create, domain: __MODULE__)
+  end
+
+  @doc "Same as `create_instance!/1` but returns `{:ok, record}` or `{:error, error}`."
+  @spec create_instance(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  def create_instance(attrs) when is_map(attrs) do
+    case get_specification_by_id(Map.get(attrs, :specified_by)) do
+      {:ok, spec} ->
+        {leaf, type} = instance_leaf_for(spec)
+        Ash.create(leaf, Map.put(attrs, :type, type), action: :create, domain: __MODULE__)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp instance_leaf_for(%{type: :serviceSpecification}), do: {Diffo.Provider.Instance, :service}
+
+  defp instance_leaf_for(%{type: :resourceSpecification}),
+    do: {Diffo.Provider.ResourceInstance, :resource}
 
   @doc """
   Loads an instance by id and projects it to its concrete Service/Resource leaf.

--- a/lib/diffo/provider.ex
+++ b/lib/diffo/provider.ex
@@ -13,6 +13,41 @@ defmodule Diffo.Provider do
     description "Extensible Ash Resources and API related to Providing TMF Services and Resources"
   end
 
+  @typedoc """
+  A record produced by an Instance creator (`create_instance!/1`, `create_instance/1`) —
+  the generic Service or Resource leaf the dispatcher constructs.
+  """
+  @type instance_record :: %Diffo.Provider.Instance{} | %Diffo.Provider.ResourceInstance{}
+
+  @typedoc """
+  A record produced by a Place creator (`create_place!/2`, `create_place/2`) — one of the
+  blessed TMF place leaves the dispatcher constructs (`:PlaceRef` yields the abstract
+  `Provider.Place`).
+  """
+  @type place_record ::
+          %Diffo.Provider.Place{}
+          | %Diffo.Provider.GeographicAddress{}
+          | %Diffo.Provider.GeographicSite{}
+          | %Diffo.Provider.GeographicLocation{}
+
+  @typedoc """
+  A record produced by a Party creator (`create_party!/2`, `create_party/2`) — one of the
+  blessed TMF party leaves the dispatcher constructs (`:PartyRef`/`:Entity` yield the
+  abstract `Provider.Party`).
+  """
+  @type party_record ::
+          %Diffo.Provider.Party{}
+          | %Diffo.Provider.Organization{}
+          | %Diffo.Provider.Individual{}
+
+  @typedoc """
+  An open-world resource record. Reads project to the outermost concrete world via
+  `AshNeo4j.worlds/1` — which may be a consumer-domain leaf unknown at compile time —
+  and update/delete dispatch on whatever record they are handed. The set is therefore
+  genuinely unbounded: a deliberate `struct()`, not a missing type.
+  """
+  @type projected_record :: struct()
+
   resources do
     resource Diffo.Provider.Specification do
       define :create_specification, action: :create
@@ -254,7 +289,7 @@ defmodule Diffo.Provider do
   Symmetric with `create_place!/2` and `create_party!/2`; dispatch is on the spec
   type rather than a passed atom, since the spec already names the kind.
   """
-  @spec create_instance!(map()) :: Ash.Resource.record()
+  @spec create_instance!(map()) :: instance_record()
   def create_instance!(attrs) when is_map(attrs) do
     {leaf, type} =
       attrs |> Map.fetch!(:specified_by) |> get_specification_by_id!() |> instance_leaf_for()
@@ -263,7 +298,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `create_instance!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec create_instance(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec create_instance(map()) :: {:ok, instance_record()} | {:error, term()}
   def create_instance(attrs) when is_map(attrs) do
     case get_specification_by_id(Map.get(attrs, :specified_by)) do
       {:ok, spec} ->
@@ -285,7 +320,7 @@ defmodule Diffo.Provider do
 
   Accepts a `:load` opt applied to the projected leaf (e.g. `load: [:event]`).
   """
-  @spec get_instance_by_id!(String.t(), keyword()) :: Ash.Resource.record()
+  @spec get_instance_by_id!(String.t(), keyword()) :: projected_record()
   def get_instance_by_id!(id, opts \\ []) when is_binary(id) do
     Diffo.Provider.Instance
     |> Ash.get!(id, domain: __MODULE__)
@@ -295,7 +330,7 @@ defmodule Diffo.Provider do
 
   @doc "Same as `get_instance_by_id!/2` but returns `{:ok, record}` or `{:error, error}`."
   @spec get_instance_by_id(String.t(), keyword()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+          {:ok, projected_record()} | {:error, term()}
   def get_instance_by_id(id, opts \\ []) when is_binary(id) do
     case Ash.get(Diffo.Provider.Instance, id, domain: __MODULE__) do
       {:ok, abstract} -> {:ok, abstract |> project_instance() |> load_projection(opts)}
@@ -311,7 +346,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists all instances, each projected to its concrete Service/Resource leaf."
-  @spec list_instances!() :: [Ash.Resource.record()]
+  @spec list_instances!() :: [projected_record()]
   def list_instances! do
     Diffo.Provider.Instance
     |> Ash.read!(action: :list, domain: __MODULE__)
@@ -319,7 +354,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds instances whose name contains the query, each projected to its concrete leaf."
-  @spec find_instances_by_name!(String.t()) :: [Ash.Resource.record()]
+  @spec find_instances_by_name!(String.t()) :: [projected_record()]
   def find_instances_by_name!(query) do
     Diffo.Provider.Instance
     |> Ash.Query.for_read(:find_by_name, %{query: query})
@@ -328,7 +363,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds instances by specification id, each projected to its concrete leaf."
-  @spec find_instances_by_specification_id!(String.t()) :: [Ash.Resource.record()]
+  @spec find_instances_by_specification_id!(String.t()) :: [projected_record()]
   def find_instances_by_specification_id!(query) do
     Diffo.Provider.Instance
     |> Ash.Query.for_read(:find_by_specification_id, %{query: query})
@@ -492,7 +527,7 @@ defmodule Diffo.Provider do
   Raises `ArgumentError` for unknown types — consumer-specific shapes go
   through consumer domains.
   """
-  @spec create_place!(place_type(), map()) :: Ash.Resource.record()
+  @spec create_place!(place_type(), map()) :: place_record()
   def create_place!(:PlaceRef, attrs) when is_map(attrs) do
     Ash.create!(Diffo.Provider.Place, attrs, action: :create, domain: __MODULE__)
   end
@@ -513,7 +548,7 @@ defmodule Diffo.Provider do
   Same as `create_place!/2` but returns `{:ok, record}` or `{:error, error}`.
   """
   @spec create_place(place_type(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+          {:ok, place_record()} | {:error, term()}
   def create_place(:PlaceRef, attrs) when is_map(attrs) do
     Ash.create(Diffo.Provider.Place, attrs, action: :create, domain: __MODULE__)
   end
@@ -535,7 +570,7 @@ defmodule Diffo.Provider do
   their `:define` action; the abstract `Provider.Place` updates via its
   inherited `:update` action.
   """
-  @spec update_place!(Ash.Resource.record(), map()) :: Ash.Resource.record()
+  @spec update_place!(projected_record(), map()) :: projected_record()
   def update_place!(%Diffo.Provider.GeographicAddress{} = record, attrs),
     do: Ash.update!(record, attrs, action: :define, domain: __MODULE__)
 
@@ -549,8 +584,8 @@ defmodule Diffo.Provider do
     do: Ash.update!(record, attrs, action: :update, domain: __MODULE__)
 
   @doc "Same as `update_place!/2` but returns `{:ok, record}` or `{:error, error}`."
-  @spec update_place(Ash.Resource.record(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec update_place(projected_record(), map()) ::
+          {:ok, projected_record()} | {:error, term()}
   def update_place(%Diffo.Provider.GeographicAddress{} = record, attrs),
     do: Ash.update(record, attrs, action: :define, domain: __MODULE__)
 
@@ -566,7 +601,7 @@ defmodule Diffo.Provider do
   @doc """
   Deletes a Place record (any subtype, dispatched on its struct module).
   """
-  @spec delete_place!(Ash.Resource.record()) :: :ok
+  @spec delete_place!(projected_record()) :: :ok
   def delete_place!(record) when is_struct(record) do
     Ash.destroy!(record, domain: __MODULE__)
     :ok
@@ -578,7 +613,7 @@ defmodule Diffo.Provider do
   Accepts either a single record or a list of records (returns
   `%Ash.BulkResult{}` for lists).
   """
-  @spec delete_place(Ash.Resource.record() | [Ash.Resource.record()]) ::
+  @spec delete_place(projected_record() | [projected_record()]) ::
           :ok | {:error, term()} | Ash.BulkResult.t()
   def delete_place(record) when is_struct(record) do
     Ash.destroy(record, domain: __MODULE__)
@@ -595,7 +630,7 @@ defmodule Diffo.Provider do
   `MyApp.SydneyExchange`, etc.) or the abstract `Provider.Place` if no
   concrete world resolves.
   """
-  @spec get_place_by_id!(String.t()) :: Ash.Resource.record()
+  @spec get_place_by_id!(String.t()) :: projected_record()
   def get_place_by_id!(id) when is_binary(id) do
     Diffo.Provider.Place
     |> Ash.get!(id, domain: __MODULE__)
@@ -603,7 +638,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `get_place_by_id!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec get_place_by_id(String.t()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec get_place_by_id(String.t()) :: {:ok, projected_record()} | {:error, term()}
   def get_place_by_id(id) when is_binary(id) do
     case Ash.get(Diffo.Provider.Place, id, domain: __MODULE__) do
       {:ok, abstract} -> {:ok, project_place(abstract)}
@@ -614,7 +649,7 @@ defmodule Diffo.Provider do
   @doc """
   Lists all Places, each projected to its outermost concrete world.
   """
-  @spec list_places!() :: [Ash.Resource.record()]
+  @spec list_places!() :: [projected_record()]
   def list_places! do
     Diffo.Provider.Place
     |> Ash.read!(action: :list, domain: __MODULE__)
@@ -622,7 +657,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `list_places!/0` but returns `{:ok, list}` or `{:error, error}`."
-  @spec list_places() :: {:ok, [Ash.Resource.record()]} | {:error, term()}
+  @spec list_places() :: {:ok, [projected_record()]} | {:error, term()}
   def list_places do
     case Ash.read(Diffo.Provider.Place, action: :list, domain: __MODULE__) do
       {:ok, places} -> {:ok, Enum.map(places, &project_place/1)}
@@ -633,7 +668,7 @@ defmodule Diffo.Provider do
   @doc """
   Finds Places whose id contains the query, each projected to its concrete world.
   """
-  @spec find_places_by_id!(String.t()) :: [Ash.Resource.record()]
+  @spec find_places_by_id!(String.t()) :: [projected_record()]
   def find_places_by_id!(query) do
     Diffo.Provider.Place
     |> Ash.Query.for_read(:find_by_id, %{query: query})
@@ -644,7 +679,7 @@ defmodule Diffo.Provider do
   @doc """
   Finds Places whose name contains the query, each projected to its concrete world.
   """
-  @spec find_places_by_name!(String.t()) :: [Ash.Resource.record()]
+  @spec find_places_by_name!(String.t()) :: [projected_record()]
   def find_places_by_name!(query) do
     Diffo.Provider.Place
     |> Ash.Query.for_read(:find_by_name, %{query: query})
@@ -696,7 +731,7 @@ defmodule Diffo.Provider do
   Raises `ArgumentError` for unknown types — consumer-specific shapes go
   through consumer domains.
   """
-  @spec create_party!(party_type(), map()) :: Ash.Resource.record()
+  @spec create_party!(party_type(), map()) :: party_record()
   def create_party!(:PartyRef, attrs) when is_map(attrs) do
     Ash.create!(Diffo.Provider.Party, attrs, action: :create, domain: __MODULE__)
   end
@@ -724,7 +759,7 @@ defmodule Diffo.Provider do
 
   @doc "Same as `create_party!/2` but returns `{:ok, record}` or `{:error, error}`."
   @spec create_party(party_type(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+          {:ok, party_record()} | {:error, term()}
   def create_party(:PartyRef, attrs) when is_map(attrs) do
     Ash.create(Diffo.Provider.Party, attrs, action: :create, domain: __MODULE__)
   end
@@ -755,7 +790,7 @@ defmodule Diffo.Provider do
   `:define` action; the abstract `Provider.Party` updates via its inherited
   `:update` action.
   """
-  @spec update_party!(Ash.Resource.record(), map()) :: Ash.Resource.record()
+  @spec update_party!(projected_record(), map()) :: projected_record()
   def update_party!(%Diffo.Provider.Organization{} = record, attrs),
     do: Ash.update!(record, attrs, action: :define, domain: __MODULE__)
 
@@ -766,8 +801,8 @@ defmodule Diffo.Provider do
     do: Ash.update!(record, attrs, action: :update, domain: __MODULE__)
 
   @doc "Same as `update_party!/2` but returns `{:ok, record}` or `{:error, error}`."
-  @spec update_party(Ash.Resource.record(), map()) ::
-          {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec update_party(projected_record(), map()) ::
+          {:ok, projected_record()} | {:error, term()}
   def update_party(%Diffo.Provider.Organization{} = record, attrs),
     do: Ash.update(record, attrs, action: :define, domain: __MODULE__)
 
@@ -778,7 +813,7 @@ defmodule Diffo.Provider do
     do: Ash.update(record, attrs, action: :update, domain: __MODULE__)
 
   @doc "Deletes a Party record (any subtype, dispatched on its struct module)."
-  @spec delete_party!(Ash.Resource.record()) :: :ok
+  @spec delete_party!(projected_record()) :: :ok
   def delete_party!(record) when is_struct(record) do
     Ash.destroy!(record, domain: __MODULE__)
     :ok
@@ -790,7 +825,7 @@ defmodule Diffo.Provider do
   Accepts either a single record or a list of records (returns
   `%Ash.BulkResult{}` for lists).
   """
-  @spec delete_party(Ash.Resource.record() | [Ash.Resource.record()]) ::
+  @spec delete_party(projected_record() | [projected_record()]) ::
           :ok | {:error, term()} | Ash.BulkResult.t()
   def delete_party(record) when is_struct(record) do
     Ash.destroy(record, domain: __MODULE__)
@@ -807,7 +842,7 @@ defmodule Diffo.Provider do
   `Provider.Individual`, `MyApp.Carrier`, etc.) or the abstract
   `Provider.Party` if no concrete world resolves.
   """
-  @spec get_party_by_id!(String.t()) :: Ash.Resource.record()
+  @spec get_party_by_id!(String.t()) :: projected_record()
   def get_party_by_id!(id) when is_binary(id) do
     Diffo.Provider.Party
     |> Ash.get!(id, domain: __MODULE__)
@@ -815,7 +850,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `get_party_by_id!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec get_party_by_id(String.t()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec get_party_by_id(String.t()) :: {:ok, projected_record()} | {:error, term()}
   def get_party_by_id(id) when is_binary(id) do
     case Ash.get(Diffo.Provider.Party, id, domain: __MODULE__) do
       {:ok, abstract} -> {:ok, project_party(abstract)}
@@ -824,7 +859,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists all Parties, each projected to its outermost concrete world."
-  @spec list_parties!() :: [Ash.Resource.record()]
+  @spec list_parties!() :: [projected_record()]
   def list_parties! do
     Diffo.Provider.Party
     |> Ash.read!(action: :list, domain: __MODULE__)
@@ -832,7 +867,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `list_parties!/0` but returns `{:ok, list}` or `{:error, error}`."
-  @spec list_parties() :: {:ok, [Ash.Resource.record()]} | {:error, term()}
+  @spec list_parties() :: {:ok, [projected_record()]} | {:error, term()}
   def list_parties do
     case Ash.read(Diffo.Provider.Party, action: :list, domain: __MODULE__) do
       {:ok, parties} -> {:ok, Enum.map(parties, &project_party/1)}
@@ -841,7 +876,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds Parties whose id contains the query, each projected to its concrete world."
-  @spec find_parties_by_id!(String.t()) :: [Ash.Resource.record()]
+  @spec find_parties_by_id!(String.t()) :: [projected_record()]
   def find_parties_by_id!(query) do
     Diffo.Provider.Party
     |> Ash.Query.for_read(:find_by_id, %{query: query})
@@ -850,7 +885,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Finds Parties whose name contains the query, each projected to its concrete world."
-  @spec find_parties_by_name!(String.t()) :: [Ash.Resource.record()]
+  @spec find_parties_by_name!(String.t()) :: [projected_record()]
   def find_parties_by_name!(query) do
     Diffo.Provider.Party
     |> Ash.Query.for_read(:find_by_name, %{query: query})
@@ -898,7 +933,7 @@ defmodule Diffo.Provider do
       target: "LOC-001"
       target: some_place_struct
   """
-  @spec create_place_ref!(map()) :: Ash.Resource.record()
+  @spec create_place_ref!(map()) :: %Diffo.Provider.PlaceRef{}
   def create_place_ref!(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -909,7 +944,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `create_place_ref!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec create_place_ref(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec create_place_ref(map()) :: {:ok, %Diffo.Provider.PlaceRef{}} | {:error, term()}
   def create_place_ref(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -922,8 +957,8 @@ defmodule Diffo.Provider do
   @doc """
   Lists PlaceRefs whose source matches the given Instance/Party/Place.
   """
-  @spec list_place_refs_from(tagged_source() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_place_refs_from(tagged_source() | projected_record()) ::
+          [%Diffo.Provider.PlaceRef{}]
   def list_place_refs_from({:instance, id}),
     do: list_place_refs_by_instance_id!(id)
 
@@ -940,8 +975,8 @@ defmodule Diffo.Provider do
   @doc """
   Lists PlaceRefs targeting the given Place.
   """
-  @spec list_place_refs_targeting(String.t() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_place_refs_targeting(String.t() | projected_record()) ::
+          [%Diffo.Provider.PlaceRef{}]
   def list_place_refs_targeting(target) do
     list_place_refs_by_place_id!(normalize_target_id(target))
   end
@@ -958,7 +993,7 @@ defmodule Diffo.Provider do
       source: some_place_struct
       source: some_party_struct
   """
-  @spec create_party_ref!(map()) :: Ash.Resource.record()
+  @spec create_party_ref!(map()) :: %Diffo.Provider.PartyRef{}
   def create_party_ref!(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -969,7 +1004,7 @@ defmodule Diffo.Provider do
   end
 
   @doc "Same as `create_party_ref!/1` but returns `{:ok, record}` or `{:error, error}`."
-  @spec create_party_ref(map()) :: {:ok, Ash.Resource.record()} | {:error, term()}
+  @spec create_party_ref(map()) :: {:ok, %Diffo.Provider.PartyRef{}} | {:error, term()}
   def create_party_ref(%{role: _, source: source, target: target} = attrs) do
     attrs
     |> Map.delete(:source)
@@ -980,8 +1015,8 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists PartyRefs whose source matches the given Instance/Place/Party."
-  @spec list_party_refs_from(tagged_source() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_party_refs_from(tagged_source() | projected_record()) ::
+          [%Diffo.Provider.PartyRef{}]
   def list_party_refs_from({:instance, id}),
     do: list_party_refs_by_instance_id!(id)
 
@@ -996,8 +1031,8 @@ defmodule Diffo.Provider do
   end
 
   @doc "Lists PartyRefs targeting the given Party."
-  @spec list_party_refs_targeting(String.t() | Ash.Resource.record()) ::
-          [Ash.Resource.record()]
+  @spec list_party_refs_targeting(String.t() | projected_record()) ::
+          [%Diffo.Provider.PartyRef{}]
   def list_party_refs_targeting(target) do
     list_party_refs_by_party_id!(normalize_target_id(target))
   end

--- a/lib/diffo/provider/components/instance.ex
+++ b/lib/diffo/provider/components/instance.ex
@@ -14,8 +14,9 @@ defmodule Diffo.Provider.Instance do
   Service/Resource leaf) via `AshNeo4j.worlds/1` before returning.
 
   An instance is **exactly one** of Service or Resource. Concrete Resource
-  instances compose `[BaseInstance, Resource]` on their own leaf (e.g.
-  `Diffo.Test.Instance.ResourceInstance`); they carry no service lifecycle.
+  instances compose `[BaseInstance, Resource]` on their own leaf — the generic
+  `Diffo.Provider.ResourceInstance`, or a consumer leaf like `MyApp.Card`; they
+  carry no service lifecycle.
 
   See `Diffo.Provider.BaseInstance` for the shared base, `Diffo.Provider.Service`
   and `Diffo.Provider.Resource` for the subtype fragments.

--- a/lib/diffo/provider/components/resource_instance.ex
+++ b/lib/diffo/provider/components/resource_instance.ex
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 diffo contributors <https://github.com/diffo-dev/diffo/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Diffo.Provider.ResourceInstance do
+  @moduledoc """
+  The generic TMF Resource Instance — the resource-flavoured counterpart to
+  `Diffo.Provider.Instance` (the generic Service).
+
+  Composes `[BaseInstance, Resource]`, so it is a concrete Resource carrying the
+  resource lifecycle (`lifecycle_state` and the TMF639 status attributes), usable
+  directly. `Diffo.Provider.create_instance!/1` dispatches here when the referenced
+  specification is a `:resourceSpecification`.
+
+  An instance is **exactly one** of Service or Resource: this leaf carries the
+  resource lifecycle, not the service state machine. Reads still go through the
+  abstract reader `Diffo.Provider.Instance`, which projects each record to its
+  outermost concrete world via `AshNeo4j.worlds/1`.
+
+  See `Diffo.Provider.Resource` for the resource subtype fragment and
+  `Diffo.Provider.BaseInstance` for the shared base.
+  """
+  alias Diffo.Provider.BaseInstance
+  alias Diffo.Provider.Resource
+
+  use Ash.Resource,
+    fragments: [BaseInstance, Resource],
+    domain: Diffo.Provider
+
+  resource do
+    description "An Ash Resource for a TMF Resource Instance"
+    plural_name :resource_instances
+  end
+end

--- a/test/provider/instance_test.exs
+++ b/test/provider/instance_test.exs
@@ -245,6 +245,45 @@ defmodule Diffo.Provider.InstanceTest do
                )
     end
 
+    test "create_instance! dispatches a serviceSpecification to the generic Service" do
+      spec = Diffo.Provider.create_specification!(%{name: "broadband"})
+
+      instance = Diffo.Provider.create_instance!(%{name: "broadband_0001", specified_by: spec.id})
+
+      assert %Diffo.Provider.Instance{} = instance
+      assert instance.type == :service
+    end
+
+    test "create_instance! dispatches a resourceSpecification to the generic Resource" do
+      spec =
+        Diffo.Provider.create_specification!(%{
+          name: "copperPath",
+          type: :resourceSpecification,
+          description: "Copper Path Resource"
+        })
+
+      instance =
+        Diffo.Provider.create_instance!(%{name: "copperPath_0001", specified_by: spec.id})
+
+      assert %Diffo.Provider.ResourceInstance{} = instance
+      assert instance.type == :resource
+    end
+
+    test "create_instance/1 returns {:ok, instance} for a valid spec" do
+      spec = Diffo.Provider.create_specification!(%{name: "evcAccess"})
+
+      assert {:ok, %Diffo.Provider.Instance{type: :service}} =
+               Diffo.Provider.create_instance(%{name: "evcAccess_0001", specified_by: spec.id})
+    end
+
+    test "create_instance/1 returns {:error, _} when the specification is missing" do
+      assert {:error, _} =
+               Diffo.Provider.create_instance(%{
+                 name: "ghost",
+                 specified_by: "00000000-0000-0000-0000-000000000000"
+               })
+    end
+
     test "create instance with characteristics - success" do
       specification = Diffo.Provider.create_specification!(%{name: "evc"})
 


### PR DESCRIPTION
Fixes #244 — restores instance creation to the public dispatcher API, plus a precise type pass that clears all `mix docs` warnings.

## 1. Public `create_instance` (commit 1)
- New library leaf **`Diffo.Provider.ResourceInstance`** (`BaseInstance + Resource`), the generic Resource counterpart to `Diffo.Provider.Instance` (the generic Service); registered in the `Diffo.Provider` domain.
- New **`Diffo.Provider.create_instance/1` + `create_instance!/1`**, dispatching on the referenced spec's type (`:serviceSpecification` → `Provider.Instance`, `:resourceSpecification` → `Provider.ResourceInstance`) — symmetric with `create_place!/2` / `create_party!/2`.
- 4 new tests (both dispatch paths + ok/error tuples). `Diffo.Test.create_instance!` left as-is (it routes to the Servo test domain's own leaf — the consumer pattern, not duplication).

## 2. Precise dispatcher typespecs + zero doc warnings (commit 2)
The specs referenced `Ash.Resource.record()` — **a type Ash doesn't define** — in 45 places; every one was an ExDoc warning that only surfaced *en masse* at `mix hex.publish`. Replaced with real, resolvable types that also sharpen the contract:
- **Creators** → closed unions: `instance_record`, `place_record`, `party_record`.
- **Ref creators/lists** → concrete `%Provider.PlaceRef{}` / `%Provider.PartyRef{}`.
- **Projecting reads + update/delete-by-record** → `projected_record :: struct()` — genuinely open-world (projection can yield a consumer-domain leaf), documented as a deliberate `struct()`.

`mix docs` now emits **zero** warnings. AGENTS.md gains a docs-warnings-are-failures rule and a release pre-flight (tests / format / docs-clean / consumer-doc currency).

## Verification
- Full suite **909 passing** (90 doctests). `mix format --check-formatted` clean. `mix compile --warnings-as-errors` clean. `mix docs` zero warnings.

Folds into the held v0.9.0 (with #243).
